### PR TITLE
Trabajar en issue 36 de la aplicación

### DIFF
--- a/app/adapter/in/fuegoapi/request/optimize_fleet_request.go
+++ b/app/adapter/in/fuegoapi/request/optimize_fleet_request.go
@@ -76,7 +76,6 @@ type OptimizeFleetVisitLocation struct {
 	AddressInfo  OptimizeFleetAddressInfo `json:"addressInfo"`
 	NodeInfo     OptimizeFleetNodeInfo    `json:"nodeInfo"`
 	ServiceTime  int64                    `json:"serviceTime"`
-	Skills       []string                 `json:"skills"`
 	TimeWindow   OptimizeFleetTimeWindow  `json:"timeWindow"`
 }
 
@@ -95,6 +94,7 @@ type OptimizeFleetDeliveryUnit struct {
 	Volume    int64               `json:"volume"`
 	Weight    int64               `json:"weight"`
 	Lpn       string              `json:"lpn"`
+	Skills    []string            `json:"skills"`
 }
 
 type OptimizeFleetItem struct {
@@ -194,7 +194,6 @@ func (r *OptimizeFleetRequest) Map() optimization.FleetOptimization {
 				ReferenceID: v.Pickup.NodeInfo.ReferenceID,
 			},
 			ServiceTime: v.Pickup.ServiceTime,
-			Skills:      v.Pickup.Skills,
 			TimeWindow: optimization.TimeWindow{
 				Start: v.Pickup.TimeWindow.Start,
 				End:   v.Pickup.TimeWindow.End,
@@ -229,7 +228,6 @@ func (r *OptimizeFleetRequest) Map() optimization.FleetOptimization {
 				ReferenceID: v.Delivery.NodeInfo.ReferenceID,
 			},
 			ServiceTime: v.Delivery.ServiceTime,
-			Skills:      v.Delivery.Skills,
 			TimeWindow: optimization.TimeWindow{
 				Start: v.Delivery.TimeWindow.Start,
 				End:   v.Delivery.TimeWindow.End,
@@ -252,6 +250,7 @@ func (r *OptimizeFleetRequest) Map() optimization.FleetOptimization {
 					Volume:    du.Volume,
 					Weight:    du.Weight,
 					Lpn:       du.Lpn,
+					Skills:    du.Skills,
 				}
 			}
 			orders[j] = optimization.Order{

--- a/app/adapter/in/fuegoapi/request/test_data_generator.go
+++ b/app/adapter/in/fuegoapi/request/test_data_generator.go
@@ -222,7 +222,6 @@ func generateVisits() []OptimizeFleetVisit {
 				AddressInfo:  addressInfo,
 				NodeInfo:     OptimizeFleetNodeInfo{ReferenceID: fmt.Sprintf("delivery-%s-%04d", zoneName, i+1)},
 				ServiceTime:  30,
-				Skills:       []string{"delivery"},
 				TimeWindow: OptimizeFleetTimeWindow{
 					Start: "08:00",
 					End:   "23:00",
@@ -239,6 +238,7 @@ func generateVisits() []OptimizeFleetVisit {
 							Volume:    (9000 + rand.Int63n(12000)) / 10, // Proporcional al insurance
 							Weight:    (9000 + rand.Int63n(12000)) / 10, // Mismo valor que volume
 							Lpn:       fmt.Sprintf("LPN%04d", i+1),
+							Skills:    []string{"delivery"},
 						},
 					},
 					ReferenceID: fmt.Sprintf("ORD%04d", i+1),

--- a/app/domain/optimization/optimization.go
+++ b/app/domain/optimization/optimization.go
@@ -65,7 +65,6 @@ type VisitLocation struct {
 	AddressInfo  AddressInfo
 	NodeInfo     NodeInfo
 	ServiceTime  int64
-	Skills       []string
 	TimeWindow   TimeWindow
 }
 
@@ -81,6 +80,7 @@ type DeliveryUnit struct {
 	Volume    int64
 	Weight    int64
 	Lpn       string
+	Skills    []string
 }
 
 // Order representa una orden


### PR DESCRIPTION
Relocate `skills` from `visit.delivery` and `visit.pickup` to `deliveryUnits` to accurately reflect that skills belong to packages/orders, not visit locations.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-2788a1fb-9f93-4a18-8526-e1e1f5c53581) · [Cursor](https://cursor.com/background-agent?bcId=bc-2788a1fb-9f93-4a18-8526-e1e1f5c53581)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)