### PR TITLE
Implementar patron FSM en repositorios

### DIFF
--- a/app/adapter/out/tidbrepository/find_account_by_email_test.go
+++ b/app/adapter/out/tidbrepository/find_account_by_email_test.go
@@ -27,7 +27,7 @@ var _ = Describe("FindAccountByEmail", func() {
 		account := domain.Account{
 			Email: "test@example.com",
 		}
-		err := NewUpsertAccount(connection, NewSaveFSMTransition(connection))(ctx, account)
+		err := NewUpsertAccount(connection, nil)(ctx, account)
 		Expect(err).ToNot(HaveOccurred())
 
 		findAccount := NewFindAccountByEmail(connection)

--- a/app/adapter/out/tidbrepository/find_default_tenant_by_email_test.go
+++ b/app/adapter/out/tidbrepository/find_default_tenant_by_email_test.go
@@ -30,7 +30,7 @@ var _ = Describe("FindDefaultTenantByEmail", func() {
 		account := domain.Account{
 			Email: "test@example.com",
 		}
-		err = NewUpsertAccount(connection, NewSaveFSMTransition(connection))(ctx, account)
+		err = NewUpsertAccount(connection, nil)(ctx, account)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create tenant account link (not invited)
@@ -41,7 +41,7 @@ var _ = Describe("FindDefaultTenantByEmail", func() {
 			Status:  "active",
 			Invited: false,
 		}
-		err = NewSaveTenantAccount(connection, NewSaveFSMTransition(connection))(tenantCtx, tenantAccount)
+		err = NewSaveTenantAccount(connection, nil)(tenantCtx, tenantAccount)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Test find function
@@ -66,7 +66,7 @@ var _ = Describe("FindDefaultTenantByEmail", func() {
 		account := domain.Account{
 			Email: "invited@example.com",
 		}
-		err = NewUpsertAccount(connection, NewSaveFSMTransition(connection))(ctx, account)
+		err = NewUpsertAccount(connection, nil)(ctx, account)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create tenant account link (invited)
@@ -77,7 +77,7 @@ var _ = Describe("FindDefaultTenantByEmail", func() {
 			Status:  "pending",
 			Invited: true,
 		}
-		err = NewSaveTenantAccount(connection, NewSaveFSMTransition(connection))(tenantCtx, tenantAccount)
+		err = NewSaveTenantAccount(connection, nil)(tenantCtx, tenantAccount)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Test find function - should not find invited account

--- a/app/adapter/out/tidbrepository/find_delivery_units_projection_result_test.go
+++ b/app/adapter/out/tidbrepository/find_delivery_units_projection_result_test.go
@@ -82,7 +82,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		err = NewUpsertAddressInfo(conn, nil)(ctx, destination)
 		Expect(err).ToNot(HaveOccurred(), "Failed to upsert address info: %v", err)
 
-		err = NewUpsertPoliticalArea(conn)(ctx, politicalArea)
+		err = NewUpsertPoliticalArea(conn, nil)(ctx, politicalArea)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify address was created
@@ -123,7 +123,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				ServiceCategory: "STANDARD",
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred(), "Failed to upsert order: %v", err)
 
 		// Verify order was created
@@ -136,7 +136,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		Expect(orderCount).To(Equal(int64(1)), "Order was not created properly")
 
 		// Create delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -258,7 +258,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				},
 			},
 		}
-		err = NewUpsertContact(conn)(ctx, contact)
+		err = NewUpsertContact(conn, nil)(ctx, contact)
 		Expect(err).ToNot(HaveOccurred())
 
 		destination := domain.AddressInfo{
@@ -312,10 +312,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				ServiceCategory: "STANDARD",
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -385,7 +385,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 			},
 		}
 
-		err = NewUpsertDeliveryUnits(conn)(ctx, []domain.DeliveryUnit{deliveryUnit})
+		err = NewUpsertDeliveryUnits(conn, nil)(ctx, []domain.DeliveryUnit{deliveryUnit})
 		Expect(err).ToNot(HaveOccurred())
 
 		order := domain.Order{
@@ -398,13 +398,13 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				deliveryUnit,
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = NewUpsertOrderHeaders(conn, nil)(ctx, order.Headers)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -472,10 +472,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -518,7 +518,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 			Type:        "EXPRESS",
 			Description: "Entrega express",
 		}
-		err = NewUpsertOrderType(conn)(ctx, orderType)
+		err = NewUpsertOrderType(conn, nil)(ctx, orderType)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear order con order type
@@ -529,10 +529,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -583,11 +583,11 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear delivery units history con status
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -657,10 +657,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertOrderReferences(conn)(ctx, order)
+		err = NewUpsertOrderReferences(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verificar que las referencias se crearon
@@ -672,7 +672,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(refCount).To(Equal(int64(3)), "Order references were not created properly")
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -728,10 +728,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 			},
 		}
 
-		err = NewUpsertDeliveryUnits(conn)(ctx, []domain.DeliveryUnit{deliveryUnit})
+		err = NewUpsertDeliveryUnits(conn, nil)(ctx, []domain.DeliveryUnit{deliveryUnit})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsLabels(conn)(ctx, order)
+		err = NewUpsertDeliveryUnitsLabels(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verificar que las etiquetas se crearon correctamente
@@ -743,10 +743,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(createdLabels).To(HaveLen(3))
 
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -812,7 +812,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				},
 			},
 		}
-		err = NewUpsertContact(conn)(ctx, originContact)
+		err = NewUpsertContact(conn, nil)(ctx, originContact)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear dirección de origen
@@ -840,7 +840,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		err = NewUpsertAddressInfo(conn, nil)(ctx, origin)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertPoliticalArea(conn)(ctx, origin.PoliticalArea)
+		err = NewUpsertPoliticalArea(conn, nil)(ctx, origin.PoliticalArea)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear order con información de origen
@@ -853,10 +853,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -960,12 +960,12 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 
 		// Insertar los orders
 		for _, order := range orders {
-			err = NewUpsertOrder(conn)(ctx, order)
+			err = NewUpsertOrder(conn, nil)(ctx, order)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: orders,
@@ -1054,7 +1054,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create another order with different references
@@ -1068,16 +1068,16 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order2)
+		err = NewUpsertOrder(conn, nil)(ctx, order2)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertOrderReferences(conn)(ctx, order)
+		err = NewUpsertOrderReferences(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
-		err = NewUpsertOrderReferences(conn)(ctx, order2)
+		err = NewUpsertOrderReferences(conn, nil)(ctx, order2)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create delivery units history for both orders
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{order, order2},
@@ -1172,12 +1172,12 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 
 		// Insert orders
 		for _, order := range orders {
-			err = NewUpsertOrder(conn)(ctx, order)
+			err = NewUpsertOrder(conn, nil)(ctx, order)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		// Create delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: orders,
@@ -1294,23 +1294,23 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		}
 
 		// Insertar delivery units
-		err = NewUpsertDeliveryUnits(conn)(ctx, []domain.DeliveryUnit{deliveryUnit1, deliveryUnit2, deliveryUnit3})
+		err = NewUpsertDeliveryUnits(conn, nil)(ctx, []domain.DeliveryUnit{deliveryUnit1, deliveryUnit2, deliveryUnit3})
 		Expect(err).ToNot(HaveOccurred())
 
 		// Insertar orders
 		for _, order := range orders {
-			err = NewUpsertOrder(conn)(ctx, order)
+			err = NewUpsertOrder(conn, nil)(ctx, order)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		// Insertar labels
 		for _, order := range orders {
-			err = NewUpsertDeliveryUnitsLabels(conn)(ctx, order)
+			err = NewUpsertDeliveryUnitsLabels(conn, nil)(ctx, order)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: orders,
@@ -1432,17 +1432,17 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		}
 
 		// Insertar delivery units
-		err = NewUpsertDeliveryUnits(conn)(ctx, []domain.DeliveryUnit{deliveryUnit1, deliveryUnit2, deliveryUnit3})
+		err = NewUpsertDeliveryUnits(conn, nil)(ctx, []domain.DeliveryUnit{deliveryUnit1, deliveryUnit2, deliveryUnit3})
 		Expect(err).ToNot(HaveOccurred())
 
 		// Insertar orders
 		for _, order := range orders {
-			err = NewUpsertOrder(conn)(ctx, order)
+			err = NewUpsertOrder(conn, nil)(ctx, order)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: orders,
@@ -1660,12 +1660,12 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 
 		// Insertar orders
 		for _, order := range orders {
-			err = NewUpsertOrder(conn)(ctx, order)
+			err = NewUpsertOrder(conn, nil)(ctx, order)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: orders,
@@ -1896,7 +1896,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		originNode := domain.NodeInfo{
 			ReferenceID: "NODE-001",
 		}
-		err = NewUpsertNodeInfo(conn)(ctx, originNode)
+		err = NewUpsertNodeInfo(conn, nil)(ctx, originNode)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear orden con el nodo de origen
@@ -1907,14 +1907,14 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear otra orden con un nodo de origen diferente
 		otherOriginNode := domain.NodeInfo{
 			ReferenceID: "NODE-002",
 		}
-		err = NewUpsertNodeInfo(conn)(ctx, otherOriginNode)
+		err = NewUpsertNodeInfo(conn, nil)(ctx, otherOriginNode)
 		Expect(err).ToNot(HaveOccurred())
 
 		otherOrder := domain.Order{
@@ -1924,11 +1924,11 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, otherOrder)
+		err = NewUpsertOrder(conn, nil)(ctx, otherOrder)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear historial de unidades de entrega
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{order, otherOrder},
@@ -1994,11 +1994,11 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear múltiples estados para la misma unidad de entrega
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -2010,7 +2010,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear otro estado para la misma unidad
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -2110,7 +2110,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				ServiceCategory: "STANDARD",
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order1)
+		err = NewUpsertOrder(conn, nil)(ctx, order1)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Segunda orden
@@ -2160,11 +2160,11 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				ServiceCategory: "STANDARD",
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order2)
+		err = NewUpsertOrder(conn, nil)(ctx, order2)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear historial de unidades de entrega
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{order1, order2},
@@ -2273,17 +2273,17 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		}
 
 		// Insertar delivery units
-		err = NewUpsertDeliveryUnits(conn)(ctx, []domain.DeliveryUnit{deliveryUnit1, deliveryUnit2, deliveryUnit3})
+		err = NewUpsertDeliveryUnits(conn, nil)(ctx, []domain.DeliveryUnit{deliveryUnit1, deliveryUnit2, deliveryUnit3})
 		Expect(err).ToNot(HaveOccurred())
 
 		// Insertar orders
 		for _, order := range orders {
-			err = NewUpsertOrder(conn)(ctx, order)
+			err = NewUpsertOrder(conn, nil)(ctx, order)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: orders,
@@ -2389,12 +2389,12 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 
 		// Insertar orders
 		for _, order := range orders {
-			err = NewUpsertOrder(conn)(ctx, order)
+			err = NewUpsertOrder(conn, nil)(ctx, order)
 			Expect(err).ToNot(HaveOccurred())
 		}
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: orders,
@@ -2480,10 +2480,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -2537,11 +2537,11 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -2603,11 +2603,11 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -2660,7 +2660,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				Reason:  "Geocoding service",
 			},
 		}
-		err = NewUpsertPoliticalArea(conn)(ctx, politicalArea)
+		err = NewUpsertPoliticalArea(conn, nil)(ctx, politicalArea)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear address info con political area
@@ -2682,7 +2682,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		err = NewUpsertAddressInfo(conn, nil)(ctx, destination)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertPoliticalArea(conn)(ctx, politicalArea)
+		err = NewUpsertPoliticalArea(conn, nil)(ctx, politicalArea)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear order con el address info
@@ -2695,11 +2695,11 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				{},
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Crear delivery units history
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -2745,7 +2745,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		skill2 := domain.Skill("REFRIGERATED")
 
 		// Use the repository to persist skills
-		upsertSkill := NewUpsertSkill(conn)
+		upsertSkill := NewUpsertSkill(conn, nil)
 		err = upsertSkill(ctx, skill1)
 		Expect(err).ToNot(HaveOccurred())
 		err = upsertSkill(ctx, skill2)
@@ -2755,7 +2755,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		deliveryUnit := domain.DeliveryUnit{
 			Skills: []domain.Skill{skill1, skill2},
 		}
-		err = NewUpsertDeliveryUnits(conn)(ctx, []domain.DeliveryUnit{
+		err = NewUpsertDeliveryUnits(conn, nil)(ctx, []domain.DeliveryUnit{
 			deliveryUnit,
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -2767,10 +2767,10 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 				deliveryUnit,
 			},
 		}
-		err = NewUpsertOrder(conn)(ctx, order)
+		err = NewUpsertOrder(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsHistory(conn)(ctx, domain.Plan{
+		err = NewUpsertDeliveryUnitsHistory(conn, nil)(ctx, domain.Plan{
 			Routes: []domain.Route{
 				{
 					Orders: []domain.Order{
@@ -2781,7 +2781,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertDeliveryUnitsSkills(conn)(ctx, order)
+		err = NewUpsertDeliveryUnitsSkills(conn, nil)(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Query for delivery units with skills

--- a/app/adapter/out/tidbrepository/find_nodes_projection_result_test.go
+++ b/app/adapter/out/tidbrepository/find_nodes_projection_result_test.go
@@ -61,11 +61,11 @@ var _ = Describe("FindNodesProjectionResult", func() {
 		}
 
 		// Insert test data
-		upsert := NewUpsertNodeInfo(conn)
+		upsert := NewUpsertNodeInfo(conn, nil)
 		err = upsert(ctx, nodeInfo)
 		Expect(err).ToNot(HaveOccurred())
 
-		upsertNodeType := NewUpsertNodeType(conn)
+		upsertNodeType := NewUpsertNodeType(conn, nil)
 		err = upsertNodeType(ctx, nodeType)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -124,11 +124,11 @@ var _ = Describe("FindNodesProjectionResult", func() {
 		}
 
 		// Insert test data
-		upsert := NewUpsertNodeInfo(conn)
+		upsert := NewUpsertNodeInfo(conn, nil)
 		err = upsert(ctx, nodeInfo)
 		Expect(err).ToNot(HaveOccurred())
 
-		upsertNodeType := NewUpsertNodeType(conn)
+		upsertNodeType := NewUpsertNodeType(conn, nil)
 		err = upsertNodeType(ctx, nodeType)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -176,11 +176,11 @@ var _ = Describe("FindNodesProjectionResult", func() {
 		}
 
 		// Insert test data
-		upsert := NewUpsertNodeInfo(conn)
+		upsert := NewUpsertNodeInfo(conn, nil)
 		err = upsert(ctx, nodeInfo)
 		Expect(err).ToNot(HaveOccurred())
 
-		upsertNodeType := NewUpsertNodeType(conn)
+		upsertNodeType := NewUpsertNodeType(conn, nil)
 		err = upsertNodeType(ctx, nodeType)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -231,11 +231,11 @@ var _ = Describe("FindNodesProjectionResult", func() {
 		}
 
 		// Insert test data
-		upsert := NewUpsertNodeInfo(conn)
+		upsert := NewUpsertNodeInfo(conn, nil)
 		err = upsert(ctx, nodeInfo)
 		Expect(err).ToNot(HaveOccurred())
 
-		upsertNodeType := NewUpsertNodeType(conn)
+		upsertNodeType := NewUpsertNodeType(conn, nil)
 		err = upsertNodeType(ctx, nodeType)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -243,7 +243,7 @@ var _ = Describe("FindNodesProjectionResult", func() {
 		err = upsertAddressInfo(ctx, addressInfo)
 		Expect(err).ToNot(HaveOccurred())
 
-		upsertNodeReferences := NewUpsertNodeReferences(conn)
+		upsertNodeReferences := NewUpsertNodeReferences(conn, nil)
 		err = upsertNodeReferences(ctx, nodeInfo)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -297,11 +297,11 @@ var _ = Describe("FindNodesProjectionResult", func() {
 		}
 
 		// Insert test data
-		upsert := NewUpsertNodeInfo(conn)
+		upsert := NewUpsertNodeInfo(conn, nil)
 		err = upsert(ctx, nodeInfo)
 		Expect(err).ToNot(HaveOccurred())
 
-		upsertNodeType := NewUpsertNodeType(conn)
+		upsertNodeType := NewUpsertNodeType(conn, nil)
 		err = upsertNodeType(ctx, nodeType)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/app/adapter/out/tidbrepository/save_tenant.go
+++ b/app/adapter/out/tidbrepository/save_tenant.go
@@ -39,7 +39,7 @@ func NewSaveTenant(conn database.ConnectionFactory, saveFSMTransition SaveFSMTra
 					Name:    existing.Name,
 					Country: tenant.Country,
 				}
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -63,7 +63,7 @@ func NewSaveTenant(conn database.ConnectionFactory, saveFSMTransition SaveFSMTra
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/save_tenant_account.go
+++ b/app/adapter/out/tidbrepository/save_tenant_account.go
@@ -53,7 +53,7 @@ func NewSaveTenantAccount(conn database.ConnectionFactory, saveFSMTransition Sav
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_account.go
+++ b/app/adapter/out/tidbrepository/upsert_account.go
@@ -30,7 +30,7 @@ func NewUpsertAccount(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 			}
 			if err == nil {
 				// La cuenta ya existe, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -43,7 +43,7 @@ func NewUpsertAccount(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_address_info.go
+++ b/app/adapter/out/tidbrepository/upsert_address_info.go
@@ -57,7 +57,7 @@ func NewUpsertAddressInfo(conn database.ConnectionFactory, saveFSMTransition Sav
 			}
 
 			// Guardar FSMState si se provee
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 			return nil

--- a/app/adapter/out/tidbrepository/upsert_address_info_test.go
+++ b/app/adapter/out/tidbrepository/upsert_address_info_test.go
@@ -59,7 +59,7 @@ var _ = Describe("UpsertAddressInfo", func() {
 		err = upsert(ctx, addressInfo)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = NewUpsertPoliticalArea(conn)(ctx, politicalArea)
+		err = NewUpsertPoliticalArea(conn, nil)(ctx, politicalArea)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify political area was created

--- a/app/adapter/out/tidbrepository/upsert_carrier.go
+++ b/app/adapter/out/tidbrepository/upsert_carrier.go
@@ -41,7 +41,7 @@ func NewUpsertCarrier(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -51,7 +51,7 @@ func NewUpsertCarrier(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 			updated, changed := existing.Map().UpdateIfChanged(c)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -66,7 +66,7 @@ func NewUpsertCarrier(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_carrier_test.go
+++ b/app/adapter/out/tidbrepository/upsert_carrier_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertCarrier", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertCarrier(conn)
+		upsert = NewUpsertCarrier(conn, nil)
 	})
 
 	It("should insert carrier if not exists", func() {
@@ -166,7 +166,7 @@ var _ = Describe("UpsertCarrier", func() {
 			NationalID: "44444444-4",
 		}
 
-		upsert := NewUpsertCarrier(noTablesContainerConnection)
+		upsert := NewUpsertCarrier(noTablesContainerConnection, nil)
 		err = upsert(ctx, carrier)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_client_credentials.go
+++ b/app/adapter/out/tidbrepository/upsert_client_credentials.go
@@ -66,7 +66,7 @@ func NewUpsertClientCredentials(conn database.ConnectionFactory, encryptionServi
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_contact.go
+++ b/app/adapter/out/tidbrepository/upsert_contact.go
@@ -12,40 +12,63 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertContact func(ctx context.Context, c domain.Contact) error
+type UpsertContact func(ctx context.Context, c domain.Contact, fsmState ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertContact, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertContact, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertContact(conn database.ConnectionFactory) UpsertContact {
-	return func(ctx context.Context, c domain.Contact) error {
-		var existing table.Contact
-		err := conn.DB.WithContext(ctx).
-			Table("contacts").
-			Where("document_id = ?", c.DocID(ctx)).
-			First(&existing).Error
+func NewUpsertContact(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertContact {
+	return func(ctx context.Context, c domain.Contact, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.Contact
+			err := tx.WithContext(ctx).
+				Table("contacts").
+				Where("document_id = ?", c.DocID(ctx)).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// No existe → insert
-			newContact := mapper.MapContactToTable(ctx, c)
-			return conn.Omit("Tenant").Create(&newContact).Error
-		}
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// No existe → insert
+				newContact := mapper.MapContactToTable(ctx, c)
+				if err := tx.Omit("Tenant").Create(&newContact).Error; err != nil {
+					return err
+				}
 
-		// Ya existe → update solo si cambió algo
-		updated, changed := existing.Map().UpdateIfChanged(c)
-		if !changed {
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+
+			// Ya existe → update solo si cambió algo
+			updated, changed := existing.Map().UpdateIfChanged(c)
+			if !changed {
+				// No cambió, solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+
+			updateData := mapper.MapContactToTable(ctx, updated)
+			updateData.ID = existing.ID // necesario para que GORM haga UPDATE
+			updateData.CreatedAt = existing.CreatedAt
+
+			if err := tx.Omit("Tenant").Save(&updateData).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
 			return nil
-		}
-
-		updateData := mapper.MapContactToTable(ctx, updated)
-		updateData.ID = existing.ID // necesario para que GORM haga UPDATE
-		updateData.CreatedAt = existing.CreatedAt
-
-		return conn.Omit("Tenant").Save(&updateData).Error
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_contact.go
+++ b/app/adapter/out/tidbrepository/upsert_contact.go
@@ -39,7 +39,7 @@ func NewUpsertContact(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -49,7 +49,7 @@ func NewUpsertContact(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 			updated, changed := existing.Map().UpdateIfChanged(c)
 			if !changed {
 				// No cambió, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -64,7 +64,7 @@ func NewUpsertContact(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_contact_test.go
+++ b/app/adapter/out/tidbrepository/upsert_contact_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertContact", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertContact(conn)
+		upsert = NewUpsertContact(conn, nil)
 	})
 
 	It("should insert contact if not exists", func() {
@@ -218,7 +218,7 @@ var _ = Describe("UpsertContact", func() {
 			PrimaryEmail: "fail@example.com",
 		}
 
-		upsert := NewUpsertContact(noTablesContainerConnection)
+		upsert := NewUpsertContact(noTablesContainerConnection, nil)
 		err = upsert(ctx, contact)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_delivery_units.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units.go
@@ -8,84 +8,95 @@ import (
 	"transport-app/app/shared/infrastructure/database"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"gorm.io/gorm"
 )
 
-type UpsertDeliveryUnits func(context.Context, []domain.DeliveryUnit) error
+type UpsertDeliveryUnits func(context.Context, []domain.DeliveryUnit, ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertDeliveryUnits, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertDeliveryUnits, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertDeliveryUnits(conn database.ConnectionFactory) UpsertDeliveryUnits {
-	return func(ctx context.Context, pcks []domain.DeliveryUnit) error {
-
-		// 1. Expandimos paquetes sin LPN en paquetes individuales
-		var normalized []domain.DeliveryUnit
-		for _, pkg := range pcks {
-			normalized = append(normalized, pkg)
-		}
-
-		if len(pcks) == 0 {
-			normalized = append(normalized, domain.DeliveryUnit{})
-		}
-
-		// 2. Construimos una lista de DocumentIDs
-		docIDs := make([]string, 0, len(normalized))
-		docIDToPackage := make(map[string]domain.DeliveryUnit, len(normalized))
-		for _, p := range normalized {
-			docID := string(p.DocID(ctx))
-			docIDs = append(docIDs, docID)
-			docIDToPackage[docID] = p
-		}
-
-		// 3. Traemos todos los paquetes existentes con un IN
-		var existingDBPackages []table.DeliveryUnit
-		err := conn.DB.WithContext(ctx).
-			Table("delivery_units").
-			Where("document_id IN ?", docIDs).
-			Find(&existingDBPackages).Error
-
-		if err != nil {
-			return err
-		}
-
-		// 4. Creamos un map de paquetes existentes por documentID
-		existingMap := make(map[string]table.DeliveryUnit)
-		for _, pkg := range existingDBPackages {
-			existingMap[pkg.DocumentID] = pkg
-		}
-
-		// 5. Preparamos los paquetes a upsertear
-		var DBpackagesToUpsert []table.DeliveryUnit
-		for _, docID := range docIDs {
-			domainPkg := docIDToPackage[docID]
-			if existingPkg, found := existingMap[docID]; found {
-				updatedDomainPkg, _ := existingPkg.Map().UpdateIfChanged(domainPkg)
-				updatedTablePkg := mapper.MapPackageToTable(ctx, updatedDomainPkg)
-				updatedTablePkg.SizeCategoryDoc = domainPkg.SizeCategory.DocumentID(ctx).String()
-				// Preservar campos importantes
-				updatedTablePkg.ID = existingPkg.ID
-				updatedTablePkg.CreatedAt = existingPkg.CreatedAt
-				updatedTablePkg.DocumentID = existingPkg.DocumentID
-
-				if updatedDomainPkg.Volume != nil {
-					updatedTablePkg.Volume = *updatedDomainPkg.Volume
-				}
-				if updatedDomainPkg.Weight != nil {
-					updatedTablePkg.Weight = *updatedDomainPkg.Weight
-				}
-				if updatedDomainPkg.Insurance != nil {
-					updatedTablePkg.Insurance = *updatedDomainPkg.Insurance
-				}
-
-				DBpackagesToUpsert = append(DBpackagesToUpsert, updatedTablePkg)
-			} else {
-				newTablePkg := mapper.MapPackageToTable(ctx, domainPkg)
-				DBpackagesToUpsert = append(DBpackagesToUpsert, newTablePkg)
+func NewUpsertDeliveryUnits(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertDeliveryUnits {
+	return func(ctx context.Context, pcks []domain.DeliveryUnit, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			// 1. Expandimos paquetes sin LPN en paquetes individuales
+			var normalized []domain.DeliveryUnit
+			for _, pkg := range pcks {
+				normalized = append(normalized, pkg)
 			}
-		}
 
-		// 6. Guardamos
-		return conn.Save(&DBpackagesToUpsert).Error
+			if len(pcks) == 0 {
+				normalized = append(normalized, domain.DeliveryUnit{})
+			}
+
+			// 2. Construimos una lista de DocumentIDs
+			docIDs := make([]string, 0, len(normalized))
+			docIDToPackage := make(map[string]domain.DeliveryUnit, len(normalized))
+			for _, p := range normalized {
+				docID := string(p.DocID(ctx))
+				docIDs = append(docIDs, docID)
+				docIDToPackage[docID] = p
+			}
+
+			// 3. Traemos todos los paquetes existentes con un IN
+			var existingDBPackages []table.DeliveryUnit
+			err := tx.WithContext(ctx).
+				Table("delivery_units").
+				Where("document_id IN ?", docIDs).
+				Find(&existingDBPackages).Error
+
+			if err != nil {
+				return err
+			}
+
+			// 4. Creamos un map de paquetes existentes por documentID
+			existingMap := make(map[string]table.DeliveryUnit)
+			for _, pkg := range existingDBPackages {
+				existingMap[pkg.DocumentID] = pkg
+			}
+
+			// 5. Preparamos los paquetes a upsertear
+			var DBpackagesToUpsert []table.DeliveryUnit
+			for _, docID := range docIDs {
+				domainPkg := docIDToPackage[docID]
+				if existingPkg, found := existingMap[docID]; found {
+					updatedDomainPkg, _ := existingPkg.Map().UpdateIfChanged(domainPkg)
+					updatedTablePkg := mapper.MapPackageToTable(ctx, updatedDomainPkg)
+					updatedTablePkg.SizeCategoryDoc = domainPkg.SizeCategory.DocumentID(ctx).String()
+					// Preservar campos importantes
+					updatedTablePkg.ID = existingPkg.ID
+					updatedTablePkg.CreatedAt = existingPkg.CreatedAt
+					updatedTablePkg.DocumentID = existingPkg.DocumentID
+
+					if updatedDomainPkg.Volume != nil {
+						updatedTablePkg.Volume = *updatedDomainPkg.Volume
+					}
+					if updatedDomainPkg.Weight != nil {
+						updatedTablePkg.Weight = *updatedDomainPkg.Weight
+					}
+					if updatedDomainPkg.Insurance != nil {
+						updatedTablePkg.Insurance = *updatedDomainPkg.Insurance
+					}
+
+					DBpackagesToUpsert = append(DBpackagesToUpsert, updatedTablePkg)
+				} else {
+					newTablePkg := mapper.MapPackageToTable(ctx, domainPkg)
+					DBpackagesToUpsert = append(DBpackagesToUpsert, newTablePkg)
+				}
+			}
+
+			// 6. Guardamos
+			if err := tx.Save(&DBpackagesToUpsert).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
+			return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_delivery_units.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units.go
@@ -92,7 +92,7 @@ func NewUpsertDeliveryUnits(conn database.ConnectionFactory, saveFSMTransition S
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_delivery_units_labels.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units_labels.go
@@ -40,7 +40,7 @@ func NewUpsertDeliveryUnitsLabels(conn database.ConnectionFactory, saveFSMTransi
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_delivery_units_labels_test.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units_labels_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertDeliveryUnitsLabels", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertDeliveryUnitsLabels(conn)
+		upsert = NewUpsertDeliveryUnitsLabels(conn, nil)
 	})
 
 	It("should insert delivery unit labels correctly", func() {

--- a/app/adapter/out/tidbrepository/upsert_delivery_units_skills.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units_skills.go
@@ -40,7 +40,7 @@ func NewUpsertDeliveryUnitsSkills(conn database.ConnectionFactory, saveFSMTransi
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_delivery_units_skills_test.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units_skills_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertDeliveryUnitsSkills", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertDeliveryUnitsSkills(conn)
+		upsert = NewUpsertDeliveryUnitsSkills(conn, nil)
 	})
 
 	It("should insert delivery unit skills correctly", func() {

--- a/app/adapter/out/tidbrepository/upsert_delivery_units_status_history.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units_status_history.go
@@ -43,7 +43,7 @@ func NewUpsertDeliveryUnitsHistory(conn database.ConnectionFactory, saveFSMTrans
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_delivery_units_status_history.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units_status_history.go
@@ -12,35 +12,42 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertDeliveryUnitsHistory func(ctx context.Context, c domain.Plan) error
+type UpsertDeliveryUnitsHistory func(ctx context.Context, c domain.Plan, fsmState ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertDeliveryUnitsHistory, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertDeliveryUnitsHistory, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertDeliveryUnitsHistory(conn database.ConnectionFactory) UpsertDeliveryUnitsHistory {
-	return func(ctx context.Context, c domain.Plan) error {
-		// Get all delivery units history records for this plan
-		deliveryUnitsHistory := mapper.MapDeliveryUnitsHistoryTable(ctx, c)
+func NewUpsertDeliveryUnitsHistory(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertDeliveryUnitsHistory {
+	return func(ctx context.Context, c domain.Plan, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			// Get all delivery units history records for this plan
+			deliveryUnitsHistory := mapper.MapDeliveryUnitsHistoryTable(ctx, c)
 
-		// For each delivery unit history record
-		for _, duh := range deliveryUnitsHistory {
-			var existing table.DeliveryUnitsStatusHistory
-			err := conn.DB.WithContext(ctx).
-				Table("delivery_units_status_histories").
-				Where("document_id = ?", duh.DocumentID).
-				First(&existing).Error
+			// For each delivery unit history record
+			for _, duh := range deliveryUnitsHistory {
+				var existing table.DeliveryUnitsStatusHistory
+				err := tx.WithContext(ctx).
+					Table("delivery_units_status_histories").
+					Where("document_id = ?", duh.DocumentID).
+					First(&existing).Error
 
-			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-				return err
+				if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+					return err
+				}
+
+				// No existe → insert
+				if err := tx.Create(&duh).Error; err != nil {
+					return err
+				}
 			}
 
-			// No existe → insert
-			if err := conn.Create(&duh).Error; err != nil {
-				return err
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
-		}
 
-		return nil
+			return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_delivery_units_test.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units_test.go
@@ -25,7 +25,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		_, ctx, err := CreateTestTenant(context.Background(), conn)
 		Expect(err).ToNot(HaveOccurred())
 
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx, []domain.DeliveryUnit{})
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -68,7 +68,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 
 		// Insertar los paquetes
 		packages := []domain.DeliveryUnit{package1, package2}
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx, packages)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -122,7 +122,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		}
 
 		// Insertar el paquete original
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx, []domain.DeliveryUnit{originalPackage})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -177,7 +177,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 			Insurance: &ins2, // Sin seguro
 		}
 
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx1, []domain.DeliveryUnit{package1})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -225,7 +225,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 			Insurance: &ins3, // Sin seguro
 		}
 
-		upsert := NewUpsertDeliveryUnits(noTablesContainerConnection)
+		upsert := NewUpsertDeliveryUnits(noTablesContainerConnection, nil)
 		err = upsert(ctx, []domain.DeliveryUnit{package1})
 
 		Expect(err).To(HaveOccurred())
@@ -252,7 +252,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		existingDocID := existingPackage.DocID(ctx)
 
 		// Insertar el paquete inicial
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx, []domain.DeliveryUnit{existingPackage})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -338,7 +338,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 
 		// Insertar el paquete
 		//	orderRef := "ORDER-REF-001"
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx, []domain.DeliveryUnit{package1})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -381,7 +381,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 
 		// Insertar el paquete
 		//	orderRef := "ORDER-REF-002"
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx, []domain.DeliveryUnit{initialPackage})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -446,7 +446,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		}
 
 		// Insertar el paquete
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx, []domain.DeliveryUnit{initialPackage})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -501,7 +501,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		}
 
 		// Insertar con el primer tenant
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx1, []domain.DeliveryUnit{package1})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -559,7 +559,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		}
 
 		//orderRef := "ORDER-EXPLODE"
-		upsert := NewUpsertDeliveryUnits(conn)
+		upsert := NewUpsertDeliveryUnits(conn, nil)
 		err = upsert(ctx, []domain.DeliveryUnit{original})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/app/adapter/out/tidbrepository/upsert_driver.go
+++ b/app/adapter/out/tidbrepository/upsert_driver.go
@@ -41,7 +41,7 @@ func NewUpsertDriver(conn database.ConnectionFactory, saveFSMTransition SaveFSMT
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -51,7 +51,7 @@ func NewUpsertDriver(conn database.ConnectionFactory, saveFSMTransition SaveFSMT
 			updated, changed := existing.Map().UpdateIfChanged(d)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -66,7 +66,7 @@ func NewUpsertDriver(conn database.ConnectionFactory, saveFSMTransition SaveFSMT
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_driver.go
+++ b/app/adapter/out/tidbrepository/upsert_driver.go
@@ -13,41 +13,64 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertDriver func(context.Context, domain.Driver) error
+type UpsertDriver func(context.Context, domain.Driver, ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertDriver, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertDriver, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertDriver(conn database.ConnectionFactory) UpsertDriver {
-	return func(ctx context.Context, d domain.Driver) error {
-		var existing table.Driver
+func NewUpsertDriver(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertDriver {
+	return func(ctx context.Context, d domain.Driver, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.Driver
 
-		err := conn.DB.WithContext(ctx).
-			Table("drivers").
-			Where("document_id = ?", d.DocID(ctx)).
-			First(&existing).Error
+			err := tx.WithContext(ctx).
+				Table("drivers").
+				Where("document_id = ?", d.DocID(ctx)).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// No existe → insert
-			newDriver := mapper.MapDriver(ctx, d)
-			return conn.Omit("Tenant").Create(&newDriver).Error
-		}
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// No existe → insert
+				newDriver := mapper.MapDriver(ctx, d)
+				if err := tx.Omit("Tenant").Create(&newDriver).Error; err != nil {
+					return err
+				}
 
-		// Ya existe → update solo si cambió algo
-		updated, changed := existing.Map().UpdateIfChanged(d)
-		if !changed {
-			return nil // No hay cambios, no hacemos nada
-		}
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		updateData := mapper.MapDriver(ctx, updated)
-		updateData.ID = existing.ID // necesario para que GORM haga UPDATE
-		updateData.CreatedAt = existing.CreatedAt
+			// Ya existe → update solo si cambió algo
+			updated, changed := existing.Map().UpdateIfChanged(d)
+			if !changed {
+				// No hay cambios, solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		return conn.Omit("Tenant").Save(&updateData).Error
+			updateData := mapper.MapDriver(ctx, updated)
+			updateData.ID = existing.ID // necesario para que GORM haga UPDATE
+			updateData.CreatedAt = existing.CreatedAt
+
+			if err := tx.Omit("Tenant").Save(&updateData).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
+			return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_driver_test.go
+++ b/app/adapter/out/tidbrepository/upsert_driver_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertDriver", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertDriver(conn)
+		upsert = NewUpsertDriver(conn, nil)
 	})
 
 	It("should insert driver if not exists", func() {
@@ -191,7 +191,7 @@ var _ = Describe("UpsertDriver", func() {
 			NationalID: "44444444-4",
 		}
 
-		upsert := NewUpsertDriver(noTablesContainerConnection)
+		upsert := NewUpsertDriver(noTablesContainerConnection, nil)
 		err = upsert(ctx, driver)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_node_info.go
+++ b/app/adapter/out/tidbrepository/upsert_node_info.go
@@ -46,7 +46,7 @@ func NewUpsertNodeInfo(conn database.ConnectionFactory, saveFSMTransition SaveFS
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -84,7 +84,7 @@ func NewUpsertNodeInfo(conn database.ConnectionFactory, saveFSMTransition SaveFS
 
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -102,7 +102,7 @@ func NewUpsertNodeInfo(conn database.ConnectionFactory, saveFSMTransition SaveFS
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_node_info.go
+++ b/app/adapter/out/tidbrepository/upsert_node_info.go
@@ -13,79 +13,100 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertNodeInfo func(context.Context, domain.NodeInfo) error
+type UpsertNodeInfo func(context.Context, domain.NodeInfo, ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertNodeInfo, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertNodeInfo, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertNodeInfo(conn database.ConnectionFactory) UpsertNodeInfo {
-	return func(ctx context.Context, ni domain.NodeInfo) error {
-		var existing table.NodeInfo
+func NewUpsertNodeInfo(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertNodeInfo {
+	return func(ctx context.Context, ni domain.NodeInfo, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.NodeInfo
 
-		docID := ni.DocID(ctx)
-		if docID.IsZero() {
-			return errors.New("cannot persist node info with empty ReferenceID")
-		}
+			docID := ni.DocID(ctx)
+			if docID.IsZero() {
+				return errors.New("cannot persist node info with empty ReferenceID")
+			}
 
-		err := conn.DB.WithContext(ctx).
-			Table("node_infos").
-			Where("document_id = ?", docID).
-			First(&existing).Error
+			err := tx.WithContext(ctx).
+				Table("node_infos").
+				Where("document_id = ?", docID).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			newRecord := mapper.MapNodeInfoTable(ctx, ni)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				newRecord := mapper.MapNodeInfoTable(ctx, ni)
+				// Use the same Omit pattern for consistency
+				if err := tx.Create(&newRecord).Error; err != nil {
+					return err
+				}
+
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+
+			existingMapped := existing.Map()
+			updated, changed := existingMapped.UpdateIfChanged(ni)
+
+			// Verificación por hash de relaciones anidadas
+			if ni.NodeType.DocID(ctx).ShouldUpdate(existing.NodeTypeDoc) {
+				updated.NodeType = ni.NodeType
+				changed = true
+			}
+
+			contactHash := ni.AddressInfo.Contact.DocID(ctx)
+			if contactHash.ShouldUpdate(existing.ContactDoc) {
+				updated.AddressInfo.Contact = ni.AddressInfo.Contact
+				changed = true
+			}
+
+			if ni.AddressInfo.DocID(ctx).ShouldUpdate(existing.AddressInfoDoc) {
+				updated.AddressInfo = ni.AddressInfo
+				changed = true
+			}
+
+			// Manejo de headers según los tres escenarios
+			if !ni.Headers.IsEmpty() {
+				// Si las cabeceras nuevas no están vacías, actualizamos
+				updated.Headers = ni.Headers
+				changed = true
+			} else {
+				// Si las cabeceras nuevas están vacías, mantenemos las existentes
+				updated.Headers = existingMapped.Headers
+			}
+
+			if !changed {
+				// No hay cambios, solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+
+			updateData := mapper.MapNodeInfoTable(ctx, updated)
+			updateData.ID = existing.ID
+			updateData.CreatedAt = existing.CreatedAt
+
 			// Use the same Omit pattern for consistency
-			return conn.
-				Create(&newRecord).Error
-		}
+			if err := tx.Table("node_infos").
+				Where("document_id = ?", docID).
+				Updates(updateData).Error; err != nil {
+				return err
+			}
 
-		existingMapped := existing.Map()
-		updated, changed := existingMapped.UpdateIfChanged(ni)
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
 
-		// Verificación por hash de relaciones anidadas
-		if ni.NodeType.DocID(ctx).ShouldUpdate(existing.NodeTypeDoc) {
-			updated.NodeType = ni.NodeType
-			changed = true
-		}
-
-		contactHash := ni.AddressInfo.Contact.DocID(ctx)
-		if contactHash.ShouldUpdate(existing.ContactDoc) {
-			updated.AddressInfo.Contact = ni.AddressInfo.Contact
-			changed = true
-		}
-
-		if ni.AddressInfo.DocID(ctx).ShouldUpdate(existing.AddressInfoDoc) {
-			updated.AddressInfo = ni.AddressInfo
-			changed = true
-		}
-
-		// Manejo de headers según los tres escenarios
-		if !ni.Headers.IsEmpty() {
-			// Si las cabeceras nuevas no están vacías, actualizamos
-			updated.Headers = ni.Headers
-			changed = true
-		} else {
-			// Si las cabeceras nuevas están vacías, mantenemos las existentes
-			updated.Headers = existingMapped.Headers
-		}
-
-		if !changed {
 			return nil
-		}
-
-		updateData := mapper.MapNodeInfoTable(ctx, updated)
-		updateData.ID = existing.ID
-		updateData.CreatedAt = existing.CreatedAt
-
-		// Use the same Omit pattern for consistency
-		return conn.DB.WithContext(ctx).
-			Table("node_infos").
-			Where("document_id = ?", docID).
-			Updates(updateData).Error
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_node_info_headers.go
+++ b/app/adapter/out/tidbrepository/upsert_node_info_headers.go
@@ -33,7 +33,7 @@ func NewUpsertNodeInfoHeaders(conn database.ConnectionFactory, saveFSMTransition
 
 			if err == nil {
 				// Ya existe → solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -44,7 +44,7 @@ func NewUpsertNodeInfoHeaders(conn database.ConnectionFactory, saveFSMTransition
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_node_info_headers_test.go
+++ b/app/adapter/out/tidbrepository/upsert_node_info_headers_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertNodeInfoHeaders", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertNodeInfoHeaders(conn)
+		upsert = NewUpsertNodeInfoHeaders(conn, nil)
 	})
 
 	It("should insert new headers when they don't exist", func() {

--- a/app/adapter/out/tidbrepository/upsert_node_info_test.go
+++ b/app/adapter/out/tidbrepository/upsert_node_info_test.go
@@ -83,7 +83,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 			},
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 		err := upsert(ctx1, nodeInfo)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -115,7 +115,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 
 		err := upsert(ctx1, original)
 		Expect(err).ToNot(HaveOccurred())
@@ -151,7 +151,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 
 		err := upsert(ctx1, nodeInfo)
 		Expect(err).ToNot(HaveOccurred())
@@ -195,7 +195,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 			Name: "Multi Org Node",
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 		err = upsert(ctx1, nodeInfo1)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -234,7 +234,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 			AddressInfo: addressInfo1, // Contact is inside addressInfo
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 		err := upsert(ctx1, original)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -266,7 +266,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 			AddressInfo: addressInfo1, // Contains contact1
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 		err := upsert(ctx1, original)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -298,7 +298,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 			AddressInfo: addressInfo1, // Contact is inside addressInfo
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 		err := upsert(ctx1, original)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -332,7 +332,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 			},
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 		err := upsert(ctx1, original)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -403,7 +403,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 			AddressInfo: addressInfo1, // Contact is inside addressInfo
 		}
 
-		upsert := NewUpsertNodeInfo(noTablesContainerConnection)
+		upsert := NewUpsertNodeInfo(noTablesContainerConnection, nil)
 		err := upsert(ctx1, nodeInfo)
 
 		Expect(err).To(HaveOccurred())
@@ -420,7 +420,7 @@ var _ = Describe("UpsertNodeInfo", func() {
 			Headers:     domain.Headers{}, // Empty headers
 		}
 
-		upsert := NewUpsertNodeInfo(connection)
+		upsert := NewUpsertNodeInfo(connection, nil)
 		err := upsert(ctx1, node)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/app/adapter/out/tidbrepository/upsert_node_references.go
+++ b/app/adapter/out/tidbrepository/upsert_node_references.go
@@ -44,7 +44,7 @@ func NewUpsertNodeReferences(conn database.ConnectionFactory, saveFSMTransition 
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_node_type.go
+++ b/app/adapter/out/tidbrepository/upsert_node_type.go
@@ -35,7 +35,7 @@ func NewUpsertNodeType(conn database.ConnectionFactory, saveFSMTransition SaveFS
 
 			if err == nil {
 				// Ya existe → solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -49,7 +49,7 @@ func NewUpsertNodeType(conn database.ConnectionFactory, saveFSMTransition SaveFS
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_node_type.go
+++ b/app/adapter/out/tidbrepository/upsert_node_type.go
@@ -13,36 +13,47 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertNodeType func(context.Context, domain.NodeType) error
+type UpsertNodeType func(context.Context, domain.NodeType, ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertNodeType, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertNodeType, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertNodeType(conn database.ConnectionFactory) UpsertNodeType {
-	return func(ctx context.Context, nt domain.NodeType) error {
-		var existing table.NodeType
+func NewUpsertNodeType(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertNodeType {
+	return func(ctx context.Context, nt domain.NodeType, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.NodeType
 
-		err := conn.DB.WithContext(ctx).
-			Table("node_types").
-			Where("document_id = ?", nt.DocID(ctx)).
-			First(&existing).Error
+			err := tx.WithContext(ctx).
+				Table("node_types").
+				Where("document_id = ?", nt.DocID(ctx)).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if err == nil {
-			// Ya existe → no hacer nada
+			if err == nil {
+				// Ya existe → solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+			
+			newRecord := mapper.MapNodeType(ctx, nt)
+
+			err = tx.Omit("Tenant").Create(&newRecord).Error
+			if err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
 			return nil
-		}
-		newRecord := mapper.MapNodeType(ctx, nt)
-
-		err = conn.Omit("Tenant").Create(&newRecord).Error
-		if err != nil {
-			return err
-		}
-
-		return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_node_type_test.go
+++ b/app/adapter/out/tidbrepository/upsert_node_type_test.go
@@ -28,7 +28,7 @@ var _ = Describe("UpsertNodeType", func() {
 			Value: "pickup",
 		}
 
-		upsert := NewUpsertNodeType(conn)
+		upsert := NewUpsertNodeType(conn, nil)
 		err = upsert(ctx, nodeType)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -51,7 +51,7 @@ var _ = Describe("UpsertNodeType", func() {
 			Value: "original",
 		}
 
-		upsert := NewUpsertNodeType(conn)
+		upsert := NewUpsertNodeType(conn, nil)
 		err = upsert(ctx, original)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -91,7 +91,7 @@ var _ = Describe("UpsertNodeType", func() {
 			Value: "no-change",
 		}
 
-		upsert := NewUpsertNodeType(conn)
+		upsert := NewUpsertNodeType(conn, nil)
 		err = upsert(ctx, nodeType)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -133,7 +133,7 @@ var _ = Describe("UpsertNodeType", func() {
 			Value: "multi-org",
 		}
 
-		upsert := NewUpsertNodeType(conn)
+		upsert := NewUpsertNodeType(conn, nil)
 
 		err = upsert(ctx1, nodeType1)
 		Expect(err).ToNot(HaveOccurred())
@@ -174,7 +174,7 @@ var _ = Describe("UpsertNodeType", func() {
 			Value: "",
 		}
 
-		upsert := NewUpsertNodeType(conn)
+		upsert := NewUpsertNodeType(conn, nil)
 		err = upsert(ctx, nodeType)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -197,7 +197,7 @@ var _ = Describe("UpsertNodeType", func() {
 			Value: "error-case",
 		}
 
-		upsert := NewUpsertNodeType(noTablesContainerConnection)
+		upsert := NewUpsertNodeType(noTablesContainerConnection, nil)
 		err = upsert(ctx, nodeType)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_non_delivery_reason.go
+++ b/app/adapter/out/tidbrepository/upsert_non_delivery_reason.go
@@ -49,7 +49,7 @@ func NewUpsertNonDeliveryReason(conn database.ConnectionFactory, saveFSMTransiti
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -61,7 +61,7 @@ func NewUpsertNonDeliveryReason(conn database.ConnectionFactory, saveFSMTransiti
 
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -76,7 +76,7 @@ func NewUpsertNonDeliveryReason(conn database.ConnectionFactory, saveFSMTransiti
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_non_delivery_reason.go
+++ b/app/adapter/out/tidbrepository/upsert_non_delivery_reason.go
@@ -13,50 +13,74 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertNonDeliveryReason func(context.Context, domain.NonDeliveryReason) error
+type UpsertNonDeliveryReason func(context.Context, domain.NonDeliveryReason, ...domain.FSMState) error
 
 func init() {
 	ioc.Registry(
 		NewUpsertNonDeliveryReason,
 		database.NewConnectionFactory,
+		NewSaveFSMTransition,
 	)
 }
 
-func NewUpsertNonDeliveryReason(conn database.ConnectionFactory) UpsertNonDeliveryReason {
-	return func(ctx context.Context, nd domain.NonDeliveryReason) error {
-		docID := nd.DocID(ctx)
-		if docID.IsZero() {
-			return errors.New("cannot persist non delivery reason with empty doc ID")
-		}
+func NewUpsertNonDeliveryReason(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertNonDeliveryReason {
+	return func(ctx context.Context, nd domain.NonDeliveryReason, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			docID := nd.DocID(ctx)
+			if docID.IsZero() {
+				return errors.New("cannot persist non delivery reason with empty doc ID")
+			}
 
-		var existing table.NonDeliveryReason
+			var existing table.NonDeliveryReason
 
-		err := conn.DB.WithContext(ctx).
-			Table("non_delivery_reasons").
-			Where("document_id = ?", docID).
-			First(&existing).Error
+			err := tx.WithContext(ctx).
+				Table("non_delivery_reasons").
+				Where("document_id = ?", docID).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			newRecord := mapper.MapNonDeliveryReasonTable(ctx, nd)
-			return conn.Create(&newRecord).Error
-		}
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				newRecord := mapper.MapNonDeliveryReasonTable(ctx, nd)
+				if err := tx.Create(&newRecord).Error; err != nil {
+					return err
+				}
 
-		// Map and compare to check for changes
-		existingMapped := existing.Map()
-		updated, changed := existingMapped.UpdateIfChanged(nd)
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		if !changed {
+			// Map and compare to check for changes
+			existingMapped := existing.Map()
+			updated, changed := existingMapped.UpdateIfChanged(nd)
+
+			if !changed {
+				// No hay cambios, solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+
+			updateData := mapper.MapNonDeliveryReasonTable(ctx, updated)
+			updateData.ID = existing.ID
+			updateData.CreatedAt = existing.CreatedAt
+
+			if err := tx.Save(&updateData).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
 			return nil
-		}
-
-		updateData := mapper.MapNonDeliveryReasonTable(ctx, updated)
-		updateData.ID = existing.ID
-		updateData.CreatedAt = existing.CreatedAt
-
-		return conn.Save(&updateData).Error
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_non_delivery_reason_test.go
+++ b/app/adapter/out/tidbrepository/upsert_non_delivery_reason_test.go
@@ -30,7 +30,7 @@ var _ = Describe("UpsertNonDeliveryReason", func() {
 			Details:     "Cliente no estaba presente",
 		}
 
-		upsert := NewUpsertNonDeliveryReason(conn)
+		upsert := NewUpsertNonDeliveryReason(conn, nil)
 		err = upsert(ctx, reason)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -54,7 +54,7 @@ var _ = Describe("UpsertNonDeliveryReason", func() {
 			Reason:      "BAD_ADDRESS",
 			Details:     "Dirección no existe",
 		}
-		upsert := NewUpsertNonDeliveryReason(conn)
+		upsert := NewUpsertNonDeliveryReason(conn, nil)
 		err = upsert(ctx, original)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -96,7 +96,7 @@ var _ = Describe("UpsertNonDeliveryReason", func() {
 			Reason:      "INCOMPLETE_ADDRESS",
 		}
 
-		upsert := NewUpsertNonDeliveryReason(conn)
+		upsert := NewUpsertNonDeliveryReason(conn, nil)
 		err = upsert(ctx, reason)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -140,7 +140,7 @@ var _ = Describe("UpsertNonDeliveryReason", func() {
 			Details:     "Same reason for different tenants",
 		}
 
-		upsert := NewUpsertNonDeliveryReason(conn)
+		upsert := NewUpsertNonDeliveryReason(conn, nil)
 
 		err = upsert(ctx1, reason1)
 		Expect(err).ToNot(HaveOccurred())
@@ -181,7 +181,7 @@ var _ = Describe("UpsertNonDeliveryReason", func() {
 			ReferenceID: "REF-999",
 			Reason:      "DATABASE_MISSING",
 		}
-		upsert := NewUpsertNonDeliveryReason(noTablesContainerConnection)
+		upsert := NewUpsertNonDeliveryReason(noTablesContainerConnection, nil)
 		err = upsert(ctx, reason)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_order.go
+++ b/app/adapter/out/tidbrepository/upsert_order.go
@@ -40,7 +40,7 @@ func NewUpsertOrder(conn database.ConnectionFactory, saveFSMTransition SaveFSMTr
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -100,7 +100,7 @@ func NewUpsertOrder(conn database.ConnectionFactory, saveFSMTransition SaveFSMTr
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_order.go
+++ b/app/adapter/out/tidbrepository/upsert_order.go
@@ -12,87 +12,99 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertOrder func(context.Context, domain.Order) error
+type UpsertOrder func(context.Context, domain.Order, ...domain.FSMState) error
 
 func init() {
 	ioc.Registry(
 		NewUpsertOrder,
-		database.NewConnectionFactory)
+		database.NewConnectionFactory,
+		NewSaveFSMTransition)
 }
-func NewUpsertOrder(conn database.ConnectionFactory) UpsertOrder {
-	return func(ctx context.Context, o domain.Order) error {
-		var order table.Order
-		err := conn.DB.WithContext(ctx).
-			Table("orders").
-			Where("document_id = ?",
-				o.DocID(ctx)).
-			First(&order).Error
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+func NewUpsertOrder(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertOrder {
+	return func(ctx context.Context, o domain.Order, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var order table.Order
+			err := tx.WithContext(ctx).
+				Table("orders").
+				Where("document_id = ?",
+					o.DocID(ctx)).
+				First(&order).Error
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			DBOrderToCreate := mapper.MapOrderToTable(ctx, o)
-			return conn.
-				Create(&DBOrderToCreate).Error
-		}
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				DBOrderToCreate := mapper.MapOrderToTable(ctx, o)
+				if err := tx.Create(&DBOrderToCreate).Error; err != nil {
+					return err
+				}
 
-		orderWithChanges, _ := order.Map().UpdateIfChanged(o)
-		DBOrderToUpdate := mapper.MapOrderToTable(ctx, orderWithChanges)
-		// Preservar todos los IDs de documento actuales
-		DBOrderToUpdate.ID = order.ID
-		DBOrderToUpdate.OrderHeadersDoc = order.OrderHeadersDoc
-		DBOrderToUpdate.OriginNodeInfoDoc = order.OriginNodeInfoDoc
-		DBOrderToUpdate.DestinationNodeInfoDoc = order.DestinationNodeInfoDoc
-		DBOrderToUpdate.OrderTypeDoc = order.OrderTypeDoc
-		DBOrderToUpdate.OriginContactDoc = order.OriginContactDoc
-		DBOrderToUpdate.DestinationContactDoc = order.DestinationContactDoc
-		DBOrderToUpdate.OriginAddressInfoDoc = order.OriginAddressInfoDoc
-		DBOrderToUpdate.DestinationAddressInfoDoc = order.DestinationAddressInfoDoc
-		DBOrderToUpdate.CreatedAt = order.CreatedAt
-		DBOrderToUpdate.RouteDoc = order.RouteDoc
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		// Actualizar IDs de documento si han cambiado
-		if o.Headers.DocID(ctx).ShouldUpdate(order.OrderHeadersDoc) {
-			DBOrderToUpdate.OrderHeadersDoc = o.Headers.DocID(ctx).String()
-		}
+			orderWithChanges, _ := order.Map().UpdateIfChanged(o)
+			DBOrderToUpdate := mapper.MapOrderToTable(ctx, orderWithChanges)
+			// Preservar todos los IDs de documento actuales
+			DBOrderToUpdate.ID = order.ID
+			DBOrderToUpdate.OrderHeadersDoc = order.OrderHeadersDoc
+			DBOrderToUpdate.OriginNodeInfoDoc = order.OriginNodeInfoDoc
+			DBOrderToUpdate.DestinationNodeInfoDoc = order.DestinationNodeInfoDoc
+			DBOrderToUpdate.OrderTypeDoc = order.OrderTypeDoc
+			DBOrderToUpdate.OriginContactDoc = order.OriginContactDoc
+			DBOrderToUpdate.DestinationContactDoc = order.DestinationContactDoc
+			DBOrderToUpdate.OriginAddressInfoDoc = order.OriginAddressInfoDoc
+			DBOrderToUpdate.DestinationAddressInfoDoc = order.DestinationAddressInfoDoc
+			DBOrderToUpdate.CreatedAt = order.CreatedAt
+			DBOrderToUpdate.RouteDoc = order.RouteDoc
 
-		if o.Origin.DocID(ctx).ShouldUpdate(order.OriginNodeInfoDoc) {
-			DBOrderToUpdate.OriginNodeInfoDoc = o.Origin.DocID(ctx).String()
-		}
+			// Actualizar IDs de documento si han cambiado
+			if o.Headers.DocID(ctx).ShouldUpdate(order.OrderHeadersDoc) {
+				DBOrderToUpdate.OrderHeadersDoc = o.Headers.DocID(ctx).String()
+			}
 
-		if o.Destination.DocID(ctx).ShouldUpdate(order.DestinationNodeInfoDoc) {
-			DBOrderToUpdate.DestinationNodeInfoDoc = o.Destination.DocID(ctx).String()
-		}
+			if o.Origin.DocID(ctx).ShouldUpdate(order.OriginNodeInfoDoc) {
+				DBOrderToUpdate.OriginNodeInfoDoc = o.Origin.DocID(ctx).String()
+			}
 
-		if o.OrderType.DocID(ctx).ShouldUpdate(order.OrderTypeDoc) {
-			DBOrderToUpdate.OrderTypeDoc = o.OrderType.DocID(ctx).String()
-		}
+			if o.Destination.DocID(ctx).ShouldUpdate(order.DestinationNodeInfoDoc) {
+				DBOrderToUpdate.DestinationNodeInfoDoc = o.Destination.DocID(ctx).String()
+			}
 
-		originContactDoc := o.Origin.AddressInfo.Contact.DocID(ctx)
-		if originContactDoc.ShouldUpdate(order.OriginContactDoc) {
-			DBOrderToUpdate.OriginContactDoc = originContactDoc.String()
-		}
+			if o.OrderType.DocID(ctx).ShouldUpdate(order.OrderTypeDoc) {
+				DBOrderToUpdate.OrderTypeDoc = o.OrderType.DocID(ctx).String()
+			}
 
-		if o.Destination.AddressInfo.Contact.DocID(ctx).ShouldUpdate(order.DestinationContactDoc) {
-			DBOrderToUpdate.DestinationContactDoc = o.Destination.AddressInfo.Contact.DocID(ctx).String()
-		}
+			originContactDoc := o.Origin.AddressInfo.Contact.DocID(ctx)
+			if originContactDoc.ShouldUpdate(order.OriginContactDoc) {
+				DBOrderToUpdate.OriginContactDoc = originContactDoc.String()
+			}
 
-		if o.Origin.AddressInfo.DocID(ctx).ShouldUpdate(order.OriginAddressInfoDoc) {
-			DBOrderToUpdate.OriginAddressInfoDoc = o.Origin.AddressInfo.DocID(ctx).String()
-		}
+			if o.Destination.AddressInfo.Contact.DocID(ctx).ShouldUpdate(order.DestinationContactDoc) {
+				DBOrderToUpdate.DestinationContactDoc = o.Destination.AddressInfo.Contact.DocID(ctx).String()
+			}
 
-		if o.Destination.AddressInfo.DocID(ctx).ShouldUpdate(order.DestinationAddressInfoDoc) {
-			DBOrderToUpdate.DestinationAddressInfoDoc = o.Destination.AddressInfo.DocID(ctx).String()
-		}
+			if o.Origin.AddressInfo.DocID(ctx).ShouldUpdate(order.OriginAddressInfoDoc) {
+				DBOrderToUpdate.OriginAddressInfoDoc = o.Origin.AddressInfo.DocID(ctx).String()
+			}
 
-		if err := conn.Transaction(func(tx *gorm.DB) error {
-			return tx.
-				Omit("Organization").
-				Save(&DBOrderToUpdate).Error
-		}); err != nil {
-			return err
-		}
-		return nil
+			if o.Destination.AddressInfo.DocID(ctx).ShouldUpdate(order.DestinationAddressInfoDoc) {
+				DBOrderToUpdate.DestinationAddressInfoDoc = o.Destination.AddressInfo.DocID(ctx).String()
+			}
+
+			if err := tx.Omit("Organization").Save(&DBOrderToUpdate).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
+			return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_order_delivery_units.go
+++ b/app/adapter/out/tidbrepository/upsert_order_delivery_units.go
@@ -43,7 +43,7 @@ func NewUpsertOrderDeliveryUnits(conn database.ConnectionFactory, saveFSMTransit
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_order_delivery_units_test.go
+++ b/app/adapter/out/tidbrepository/upsert_order_delivery_units_test.go
@@ -37,7 +37,7 @@ var _ = Describe("UpsertOrderPackages", func() {
 			},
 		}
 
-		uop := NewUpsertOrderDeliveryUnits(conn)
+		uop := NewUpsertOrderDeliveryUnits(conn, nil)
 		err = uop(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -63,7 +63,7 @@ var _ = Describe("UpsertOrderPackages", func() {
 			},
 		}
 
-		uop := NewUpsertOrderDeliveryUnits(conn)
+		uop := NewUpsertOrderDeliveryUnits(conn, nil)
 		err = uop(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -94,7 +94,7 @@ var _ = Describe("UpsertOrderPackages", func() {
 			DeliveryUnits: []domain.DeliveryUnit{},
 		}
 
-		uop := NewUpsertOrderDeliveryUnits(conn)
+		uop := NewUpsertOrderDeliveryUnits(conn, nil)
 		err = uop(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -111,7 +111,7 @@ var _ = Describe("UpsertOrderPackages", func() {
 			},
 		}
 
-		uop := NewUpsertOrderDeliveryUnits(noTablesContainerConnection)
+		uop := NewUpsertOrderDeliveryUnits(noTablesContainerConnection, nil)
 		err = uop(ctx, order)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("order_delivery_units"))
@@ -128,7 +128,7 @@ var _ = Describe("UpsertOrderPackages", func() {
 			DeliveryUnits: []domain.DeliveryUnit{}, // no paquetes
 		}
 
-		uop := NewUpsertOrderDeliveryUnits(conn)
+		uop := NewUpsertOrderDeliveryUnits(conn, nil)
 		err = uop(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/app/adapter/out/tidbrepository/upsert_order_headers.go
+++ b/app/adapter/out/tidbrepository/upsert_order_headers.go
@@ -35,7 +35,7 @@ func NewUpsertOrderHeaders(conn database.ConnectionFactory, saveFSMTransition Sa
 
 			if err == nil {
 				// Ya existe → solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -48,7 +48,7 @@ func NewUpsertOrderHeaders(conn database.ConnectionFactory, saveFSMTransition Sa
 				return err
 			}
 
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_order_references.go
+++ b/app/adapter/out/tidbrepository/upsert_order_references.go
@@ -43,7 +43,7 @@ func NewUpsertOrderReferences(conn database.ConnectionFactory, saveFSMTransition
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_order_references.go
+++ b/app/adapter/out/tidbrepository/upsert_order_references.go
@@ -11,15 +11,16 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertOrderReferences func(context.Context, domain.Order) error
+type UpsertOrderReferences func(context.Context, domain.Order, ...domain.FSMState) error
 
 func init() {
 	ioc.Registry(
 		NewUpsertOrderReferences,
-		database.NewConnectionFactory)
+		database.NewConnectionFactory,
+		NewSaveFSMTransition)
 }
-func NewUpsertOrderReferences(conn database.ConnectionFactory) UpsertOrderReferences {
-	return func(ctx context.Context, order domain.Order) error {
+func NewUpsertOrderReferences(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertOrderReferences {
+	return func(ctx context.Context, order domain.Order, fsmState ...domain.FSMState) error {
 		orderDocID := order.DocID(ctx)
 		orderReferences := mapper.MapOrderReferences(ctx, order)
 
@@ -35,12 +36,17 @@ func NewUpsertOrderReferences(conn database.ConnectionFactory) UpsertOrderRefere
 			}
 			if len(orderReferences) == 0 {
 				if err := tx.Create(&table.OrderReferences{
-
 					OrderDoc: orderDocID.String(),
 				}).Error; err != nil {
 					return err
 				}
 			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
 			return nil
 		})
 	}

--- a/app/adapter/out/tidbrepository/upsert_order_references_test.go
+++ b/app/adapter/out/tidbrepository/upsert_order_references_test.go
@@ -35,7 +35,7 @@ var _ = Describe("UpsertOrderReferences", func() {
 			},
 		}
 
-		uor := NewUpsertOrderReferences(conn)
+		uor := NewUpsertOrderReferences(conn, nil)
 		err = uor(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -61,7 +61,7 @@ var _ = Describe("UpsertOrderReferences", func() {
 			},
 		}
 
-		uor := NewUpsertOrderReferences(conn)
+		uor := NewUpsertOrderReferences(conn, nil)
 		err = uor(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -92,7 +92,7 @@ var _ = Describe("UpsertOrderReferences", func() {
 			References:  []domain.Reference{},
 		}
 
-		uor := NewUpsertOrderReferences(conn)
+		uor := NewUpsertOrderReferences(conn, nil)
 		err = uor(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -102,7 +102,7 @@ var _ = Describe("UpsertOrderReferences", func() {
 		_, ctx, err := CreateTestTenant(context.Background(), conn)
 		Expect(err).ToNot(HaveOccurred())
 
-		uor := NewUpsertOrderReferences(noTablesContainerConnection)
+		uor := NewUpsertOrderReferences(noTablesContainerConnection, nil)
 		order := domain.Order{
 			ReferenceID: "ORD-REF-ERR",
 			References: []domain.Reference{
@@ -125,7 +125,7 @@ var _ = Describe("UpsertOrderReferences", func() {
 			References:  []domain.Reference{},
 		}
 
-		uor := NewUpsertOrderReferences(conn)
+		uor := NewUpsertOrderReferences(conn, nil)
 		err = uor(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/app/adapter/out/tidbrepository/upsert_order_test.go
+++ b/app/adapter/out/tidbrepository/upsert_order_test.go
@@ -104,7 +104,7 @@ var _ = Describe("UpsertOrder", func() {
 			},
 		}
 
-		upsert := NewUpsertOrder(connection)
+		upsert := NewUpsertOrder(connection, nil)
 		err := upsert(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -132,7 +132,7 @@ var _ = Describe("UpsertOrder", func() {
 			DeliveryInstructions: "Instrucciones originales",
 		}
 
-		upsert := NewUpsertOrder(connection)
+		upsert := NewUpsertOrder(connection, nil)
 		err := upsert(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -178,7 +178,7 @@ var _ = Describe("UpsertOrder", func() {
 			},
 		}
 
-		upsert := NewUpsertOrder(connection)
+		upsert := NewUpsertOrder(connection, nil)
 		err := upsert(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -235,7 +235,7 @@ var _ = Describe("UpsertOrder", func() {
 			},
 		}
 
-		upsert := NewUpsertOrder(connection)
+		upsert := NewUpsertOrder(connection, nil)
 		err := upsert(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -287,7 +287,7 @@ var _ = Describe("UpsertOrder", func() {
 			Destination: destNode,
 		}
 
-		upsert := NewUpsertOrder(noTablesContainerConnection)
+		upsert := NewUpsertOrder(noTablesContainerConnection, nil)
 		err := upsert(ctx, order)
 
 		Expect(err).To(HaveOccurred())
@@ -308,7 +308,7 @@ var _ = Describe("UpsertOrder", func() {
 			Destination: destNode,
 		}
 
-		upsert := NewUpsertOrder(connection)
+		upsert := NewUpsertOrder(connection, nil)
 		err := upsert(ctx, order)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/app/adapter/out/tidbrepository/upsert_order_type.go
+++ b/app/adapter/out/tidbrepository/upsert_order_type.go
@@ -41,7 +41,7 @@ func NewUpsertOrderType(conn database.ConnectionFactory, saveFSMTransition SaveF
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -51,7 +51,7 @@ func NewUpsertOrderType(conn database.ConnectionFactory, saveFSMTransition SaveF
 			updated, changed := existing.Map().UpdateIfChanged(ot)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -66,7 +66,7 @@ func NewUpsertOrderType(conn database.ConnectionFactory, saveFSMTransition SaveF
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_order_type.go
+++ b/app/adapter/out/tidbrepository/upsert_order_type.go
@@ -13,45 +13,64 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertOrderType func(context.Context, domain.OrderType) error
+type UpsertOrderType func(context.Context, domain.OrderType, ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertOrderType, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertOrderType, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertOrderType(conn database.ConnectionFactory) UpsertOrderType {
-	return func(ctx context.Context, ot domain.OrderType) error {
-		var existing table.OrderType
+func NewUpsertOrderType(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertOrderType {
+	return func(ctx context.Context, ot domain.OrderType, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.OrderType
 
-		err := conn.DB.WithContext(ctx).
-			Table("order_types").
-			Where("document_id = ?", ot.DocID(ctx)).
-			First(&existing).Error
+			err := tx.WithContext(ctx).
+				Table("order_types").
+				Where("document_id = ?", ot.DocID(ctx)).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// No existe → insert
-			newRecord := mapper.MapOrderType(ctx, ot)
-			return conn.DB.WithContext(ctx).
-				Omit("Organization").
-				Create(&newRecord).Error
-		}
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// No existe → insert
+				newRecord := mapper.MapOrderType(ctx, ot)
+				if err := tx.Omit("Organization").Create(&newRecord).Error; err != nil {
+					return err
+				}
 
-		// Ya existe → update solo si cambió algo
-		updated, changed := existing.Map().UpdateIfChanged(ot)
-		if !changed {
-			return nil // No hay cambios, no hacemos nada
-		}
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		updateData := mapper.MapOrderType(ctx, updated)
-		updateData.ID = existing.ID // necesario para que GORM haga UPDATE
-		updateData.CreatedAt = existing.CreatedAt
+			// Ya existe → update solo si cambió algo
+			updated, changed := existing.Map().UpdateIfChanged(ot)
+			if !changed {
+				// No hay cambios, solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		return conn.DB.WithContext(ctx).
-			Omit("Organization").
-			Save(&updateData).Error
+			updateData := mapper.MapOrderType(ctx, updated)
+			updateData.ID = existing.ID // necesario para que GORM haga UPDATE
+			updateData.CreatedAt = existing.CreatedAt
+
+			if err := tx.Omit("Organization").Save(&updateData).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
+			return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_order_type_test.go
+++ b/app/adapter/out/tidbrepository/upsert_order_type_test.go
@@ -15,7 +15,7 @@ var _ = Describe("UpsertOrderType", func() {
 	)
 
 	BeforeEach(func() {
-		upsert = NewUpsertOrderType(connection)
+		upsert = NewUpsertOrderType(connection, nil)
 	})
 
 	It("should insert order type if not exists", func() {
@@ -182,7 +182,7 @@ var _ = Describe("UpsertOrderType", func() {
 			Description: "Test Order Type",
 		}
 
-		upsert := NewUpsertOrderType(noTablesContainerConnection)
+		upsert := NewUpsertOrderType(noTablesContainerConnection, nil)
 		err = upsert(ctx, orderType)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_plan.go
+++ b/app/adapter/out/tidbrepository/upsert_plan.go
@@ -39,7 +39,7 @@ func NewUpsertPlan(conn database.ConnectionFactory, saveFSMTransition SaveFSMTra
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -49,7 +49,7 @@ func NewUpsertPlan(conn database.ConnectionFactory, saveFSMTransition SaveFSMTra
 			updated, changed := existing.Map().UpdateIfChanged(p)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -64,7 +64,7 @@ func NewUpsertPlan(conn database.ConnectionFactory, saveFSMTransition SaveFSMTra
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_plan.go
+++ b/app/adapter/out/tidbrepository/upsert_plan.go
@@ -12,40 +12,63 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertPlan func(ctx context.Context, p domain.Plan) error
+type UpsertPlan func(ctx context.Context, p domain.Plan, fsmState ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertPlan, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertPlan, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertPlan(conn database.ConnectionFactory) UpsertPlan {
-	return func(ctx context.Context, p domain.Plan) error {
-		var existing table.Plan
-		err := conn.DB.WithContext(ctx).
-			Table("plans").
-			Where("document_id = ?", p.DocID(ctx)).
-			First(&existing).Error
+func NewUpsertPlan(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertPlan {
+	return func(ctx context.Context, p domain.Plan, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.Plan
+			err := tx.WithContext(ctx).
+				Table("plans").
+				Where("document_id = ?", p.DocID(ctx)).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// No existe → insert
-			newPlan := mapper.MapPlanToTable(ctx, p)
-			return conn.Create(&newPlan).Error
-		}
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// No existe → insert
+				newPlan := mapper.MapPlanToTable(ctx, p)
+				if err := tx.Create(&newPlan).Error; err != nil {
+					return err
+				}
 
-		// Ya existe → update solo si cambió algo
-		updated, changed := existing.Map().UpdateIfChanged(p)
-		if !changed {
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+
+			// Ya existe → update solo si cambió algo
+			updated, changed := existing.Map().UpdateIfChanged(p)
+			if !changed {
+				// No hay cambios, solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+
+			updateData := mapper.MapPlanToTable(ctx, updated)
+			updateData.ID = existing.ID // necesario para que GORM haga UPDATE
+			updateData.CreatedAt = existing.CreatedAt
+
+			if err := tx.Save(&updateData).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
 			return nil
-		}
-
-		updateData := mapper.MapPlanToTable(ctx, updated)
-		updateData.ID = existing.ID // necesario para que GORM haga UPDATE
-		updateData.CreatedAt = existing.CreatedAt
-
-		return conn.Save(&updateData).Error
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_plan_headers.go
+++ b/app/adapter/out/tidbrepository/upsert_plan_headers.go
@@ -13,41 +13,64 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertPlanHeaders func(context.Context, domain.Headers) error
+type UpsertPlanHeaders func(context.Context, domain.Headers, ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertPlanHeaders, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertPlanHeaders, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertPlanHeaders(conn database.ConnectionFactory) UpsertPlanHeaders {
-	return func(ctx context.Context, h domain.Headers) error {
-		var existing table.PlanHeaders
+func NewUpsertPlanHeaders(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertPlanHeaders {
+	return func(ctx context.Context, h domain.Headers, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.PlanHeaders
 
-		err := conn.DB.WithContext(ctx).
-			Table("plan_headers").
-			Where("document_id = ?", h.DocID(ctx)).
-			First(&existing).Error
+			err := tx.WithContext(ctx).
+				Table("plan_headers").
+				Where("document_id = ?", h.DocID(ctx)).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// No existe → insert
-			newHeaders := mapper.MapPlanHeaders(ctx, h)
-			return conn.Omit("Tenant").Create(&newHeaders).Error
-		}
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// No existe → insert
+				newHeaders := mapper.MapPlanHeaders(ctx, h)
+				if err := tx.Omit("Tenant").Create(&newHeaders).Error; err != nil {
+					return err
+				}
 
-		// Ya existe → update solo si cambió algo
-		updated, changed := existing.Map().UpdateIfChanged(h)
-		if !changed {
-			return nil // No hay cambios, no hacemos nada
-		}
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		updateData := mapper.MapPlanHeaders(ctx, updated)
-		updateData.ID = existing.ID // necesario para que GORM haga UPDATE
-		updateData.CreatedAt = existing.CreatedAt
+			// Ya existe → update solo si cambió algo
+			updated, changed := existing.Map().UpdateIfChanged(h)
+			if !changed {
+				// No hay cambios, solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		return conn.Omit("Tenant").Save(&updateData).Error
+			updateData := mapper.MapPlanHeaders(ctx, updated)
+			updateData.ID = existing.ID // necesario para que GORM haga UPDATE
+			updateData.CreatedAt = existing.CreatedAt
+
+			if err := tx.Omit("Tenant").Save(&updateData).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
+			return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_plan_headers.go
+++ b/app/adapter/out/tidbrepository/upsert_plan_headers.go
@@ -41,7 +41,7 @@ func NewUpsertPlanHeaders(conn database.ConnectionFactory, saveFSMTransition Sav
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -51,7 +51,7 @@ func NewUpsertPlanHeaders(conn database.ConnectionFactory, saveFSMTransition Sav
 			updated, changed := existing.Map().UpdateIfChanged(h)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -66,7 +66,7 @@ func NewUpsertPlanHeaders(conn database.ConnectionFactory, saveFSMTransition Sav
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_plan_headers_test.go
+++ b/app/adapter/out/tidbrepository/upsert_plan_headers_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertPlanHeaders", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertPlanHeaders(conn)
+		upsert = NewUpsertPlanHeaders(conn, nil)
 	})
 
 	It("should insert headers if not exists", func() {
@@ -172,7 +172,7 @@ var _ = Describe("UpsertPlanHeaders", func() {
 			Channel:  "WEB",
 		}
 
-		upsert := NewUpsertPlanHeaders(noTablesContainerConnection)
+		upsert := NewUpsertPlanHeaders(noTablesContainerConnection, nil)
 		err = upsert(ctx, headers)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_plan_test.go
+++ b/app/adapter/out/tidbrepository/upsert_plan_test.go
@@ -19,7 +19,7 @@ var _ = Describe("UpsertPlan", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertPlan(conn)
+		upsert = NewUpsertPlan(conn, nil)
 	})
 
 	It("should insert plan if not exists", func() {
@@ -136,7 +136,7 @@ var _ = Describe("UpsertPlan", func() {
 			PlannedDate: time.Now(),
 		}
 
-		upsert := NewUpsertPlan(noTablesContainerConnection)
+		upsert := NewUpsertPlan(noTablesContainerConnection, nil)
 		err = upsert(ctx, plan)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_political_area.go
+++ b/app/adapter/out/tidbrepository/upsert_political_area.go
@@ -40,7 +40,7 @@ func NewUpsertPoliticalArea(conn database.ConnectionFactory, saveFSMTransition S
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -50,7 +50,7 @@ func NewUpsertPoliticalArea(conn database.ConnectionFactory, saveFSMTransition S
 			updated, changed := existing.Map().UpdateIfChanged(pa)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -65,7 +65,7 @@ func NewUpsertPoliticalArea(conn database.ConnectionFactory, saveFSMTransition S
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_political_area_test.go
+++ b/app/adapter/out/tidbrepository/upsert_political_area_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertPoliticalArea", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertPoliticalArea(conn)
+		upsert = NewUpsertPoliticalArea(conn, nil)
 	})
 
 	It("should insert political area if not exists", func() {

--- a/app/adapter/out/tidbrepository/upsert_route.go
+++ b/app/adapter/out/tidbrepository/upsert_route.go
@@ -41,7 +41,7 @@ func NewUpsertRoute(conn database.ConnectionFactory, saveFSMTransition SaveFSMTr
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -57,7 +57,7 @@ func NewUpsertRoute(conn database.ConnectionFactory, saveFSMTransition SaveFSMTr
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_route_test.go
+++ b/app/adapter/out/tidbrepository/upsert_route_test.go
@@ -26,7 +26,7 @@ var _ = Describe("UpsertRoute", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		conn = connection
-		upsert = NewUpsertRoute(conn)
+		upsert = NewUpsertRoute(conn, nil)
 
 		// Setup test data
 		testRoute = domain.Route{

--- a/app/adapter/out/tidbrepository/upsert_size_category.go
+++ b/app/adapter/out/tidbrepository/upsert_size_category.go
@@ -13,37 +13,47 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertSizeCategory func(context.Context, domain.SizeCategory) error
+type UpsertSizeCategory func(context.Context, domain.SizeCategory, ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertSizeCategory, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertSizeCategory, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertSizeCategory(conn database.ConnectionFactory) UpsertSizeCategory {
-	return func(ctx context.Context, sc domain.SizeCategory) error {
-		var existing table.SizeCategory
+func NewUpsertSizeCategory(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertSizeCategory {
+	return func(ctx context.Context, sc domain.SizeCategory, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.SizeCategory
 
-		err := conn.DB.WithContext(ctx).
-			Table("size_categories").
-			Where("document_id = ?", sc.DocumentID(ctx)).
-			First(&existing).Error
+			err := tx.WithContext(ctx).
+				Table("size_categories").
+				Where("document_id = ?", sc.DocumentID(ctx)).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if err == nil {
-			// Ya existe → no hacer nada
+			if err == nil {
+				// Ya existe → solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
+
+			newRecord := mapper.MapSizeCategory(ctx, sc)
+
+			err = tx.Create(&newRecord).Error
+			if err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
 			return nil
-		}
-
-		newRecord := mapper.MapSizeCategory(ctx, sc)
-
-		err = conn.DB.WithContext(ctx).Create(&newRecord).Error
-		if err != nil {
-			return err
-		}
-
-		return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_size_category.go
+++ b/app/adapter/out/tidbrepository/upsert_size_category.go
@@ -35,7 +35,7 @@ func NewUpsertSizeCategory(conn database.ConnectionFactory, saveFSMTransition Sa
 
 			if err == nil {
 				// Ya existe → solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -49,7 +49,7 @@ func NewUpsertSizeCategory(conn database.ConnectionFactory, saveFSMTransition Sa
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_size_category_test.go
+++ b/app/adapter/out/tidbrepository/upsert_size_category_test.go
@@ -28,7 +28,7 @@ var _ = Describe("UpsertSizeCategory", func() {
 			Code: "SMALL",
 		}
 
-		upsert := NewUpsertSizeCategory(conn)
+		upsert := NewUpsertSizeCategory(conn, nil)
 		err = upsert(ctx, sizeCategory)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -52,7 +52,7 @@ var _ = Describe("UpsertSizeCategory", func() {
 			Code: "MEDIUM",
 		}
 
-		upsert := NewUpsertSizeCategory(conn)
+		upsert := NewUpsertSizeCategory(conn, nil)
 		err = upsert(ctx, sizeCategory)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -92,7 +92,7 @@ var _ = Describe("UpsertSizeCategory", func() {
 			Code: "LARGE",
 		}
 
-		upsert := NewUpsertSizeCategory(conn)
+		upsert := NewUpsertSizeCategory(conn, nil)
 
 		// Insert for first tenant
 		err = upsert(ctx1, sizeCategory)
@@ -131,7 +131,7 @@ var _ = Describe("UpsertSizeCategory", func() {
 			Code: "ERROR",
 		}
 
-		upsert := NewUpsertSizeCategory(noTablesContainerConnection)
+		upsert := NewUpsertSizeCategory(noTablesContainerConnection, nil)
 		err = upsert(ctx, sizeCategory)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_skill.go
+++ b/app/adapter/out/tidbrepository/upsert_skill.go
@@ -34,7 +34,7 @@ func NewUpsertSkill(conn database.ConnectionFactory, saveFSMTransition SaveFSMTr
 
 			if err == nil {
 				// Ya existe → solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -52,7 +52,7 @@ func NewUpsertSkill(conn database.ConnectionFactory, saveFSMTransition SaveFSMTr
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_vehicle.go
+++ b/app/adapter/out/tidbrepository/upsert_vehicle.go
@@ -41,7 +41,7 @@ func NewUpsertVehicle(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -51,7 +51,7 @@ func NewUpsertVehicle(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 			updated, changed := existing.Map().UpdateIfChanged(v)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -66,7 +66,7 @@ func NewUpsertVehicle(conn database.ConnectionFactory, saveFSMTransition SaveFSM
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_vehicle.go
+++ b/app/adapter/out/tidbrepository/upsert_vehicle.go
@@ -13,41 +13,64 @@ import (
 	"gorm.io/gorm"
 )
 
-type UpsertVehicle func(context.Context, domain.Vehicle) error
+type UpsertVehicle func(context.Context, domain.Vehicle, ...domain.FSMState) error
 
 func init() {
-	ioc.Registry(NewUpsertVehicle, database.NewConnectionFactory)
+	ioc.Registry(NewUpsertVehicle, database.NewConnectionFactory, NewSaveFSMTransition)
 }
 
-func NewUpsertVehicle(conn database.ConnectionFactory) UpsertVehicle {
-	return func(ctx context.Context, v domain.Vehicle) error {
-		var existing table.Vehicle
+func NewUpsertVehicle(conn database.ConnectionFactory, saveFSMTransition SaveFSMTransition) UpsertVehicle {
+	return func(ctx context.Context, v domain.Vehicle, fsmState ...domain.FSMState) error {
+		return conn.Transaction(func(tx *gorm.DB) error {
+			var existing table.Vehicle
 
-		err := conn.DB.WithContext(ctx).
-			Table("vehicles").
-			Where("document_id = ?", v.DocID(ctx)).
-			First(&existing).Error
+			err := tx.WithContext(ctx).
+				Table("vehicles").
+				Where("document_id = ?", v.DocID(ctx)).
+				First(&existing).Error
 
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return err
-		}
+			if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
 
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// No existe → insert
-			newVehicle := mapper.MapVehicle(ctx, v)
-			return conn.Omit("Tenant").Create(&newVehicle).Error
-		}
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// No existe → insert
+				newVehicle := mapper.MapVehicle(ctx, v)
+				if err := tx.Omit("Tenant").Create(&newVehicle).Error; err != nil {
+					return err
+				}
 
-		// Ya existe → update solo si cambió algo
-		updated, changed := existing.Map().UpdateIfChanged(v)
-		if !changed {
-			return nil // No hay cambios, no hacemos nada
-		}
+				// Persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		updateData := mapper.MapVehicle(ctx, updated)
-		updateData.ID = existing.ID // necesario para que GORM haga UPDATE
-		updateData.CreatedAt = existing.CreatedAt
+			// Ya existe → update solo si cambió algo
+			updated, changed := existing.Map().UpdateIfChanged(v)
+			if !changed {
+				// No hay cambios, solo persistir FSMState si está presente
+				if len(fsmState) > 0 {
+					return saveFSMTransition(ctx, fsmState[0], tx)
+				}
+				return nil
+			}
 
-		return conn.Omit("Tenant").Save(&updateData).Error
+			updateData := mapper.MapVehicle(ctx, updated)
+			updateData.ID = existing.ID // necesario para que GORM haga UPDATE
+			updateData.CreatedAt = existing.CreatedAt
+
+			if err := tx.Omit("Tenant").Save(&updateData).Error; err != nil {
+				return err
+			}
+
+			// Persistir FSMState si está presente
+			if len(fsmState) > 0 {
+				return saveFSMTransition(ctx, fsmState[0], tx)
+			}
+
+			return nil
+		})
 	}
 }

--- a/app/adapter/out/tidbrepository/upsert_vehicle_category.go
+++ b/app/adapter/out/tidbrepository/upsert_vehicle_category.go
@@ -41,7 +41,7 @@ func NewUpsertVehicleCategory(conn database.ConnectionFactory, saveFSMTransition
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -51,7 +51,7 @@ func NewUpsertVehicleCategory(conn database.ConnectionFactory, saveFSMTransition
 			updated, changed := existing.Map().UpdateIfChanged(vc)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -66,7 +66,7 @@ func NewUpsertVehicleCategory(conn database.ConnectionFactory, saveFSMTransition
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_vehicle_category_test.go
+++ b/app/adapter/out/tidbrepository/upsert_vehicle_category_test.go
@@ -29,7 +29,7 @@ var _ = Describe("UpsertVehicleCategory", func() {
 			MaxPackagesQuantity: 100,
 		}
 
-		upsert := NewUpsertVehicleCategory(conn)
+		upsert := NewUpsertVehicleCategory(conn, nil)
 		err = upsert(ctx, vehicleCategory)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -55,7 +55,7 @@ var _ = Describe("UpsertVehicleCategory", func() {
 			MaxPackagesQuantity: 50,
 		}
 
-		upsert := NewUpsertVehicleCategory(conn)
+		upsert := NewUpsertVehicleCategory(conn, nil)
 		err = upsert(ctx, original)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -89,7 +89,7 @@ var _ = Describe("UpsertVehicleCategory", func() {
 			MaxPackagesQuantity: 100,
 		}
 
-		upsert := NewUpsertVehicleCategory(conn)
+		upsert := NewUpsertVehicleCategory(conn, nil)
 		err = upsert(ctx, original)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/app/adapter/out/tidbrepository/upsert_vehicle_headers.go
+++ b/app/adapter/out/tidbrepository/upsert_vehicle_headers.go
@@ -41,7 +41,7 @@ func NewUpsertVehicleHeaders(conn database.ConnectionFactory, saveFSMTransition 
 				}
 
 				// Persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -51,7 +51,7 @@ func NewUpsertVehicleHeaders(conn database.ConnectionFactory, saveFSMTransition 
 			updated, changed := existing.Map().UpdateIfChanged(h)
 			if !changed {
 				// No hay cambios, solo persistir FSMState si está presente
-				if len(fsmState) > 0 {
+				if len(fsmState) > 0 && saveFSMTransition != nil {
 					return saveFSMTransition(ctx, fsmState[0], tx)
 				}
 				return nil
@@ -66,7 +66,7 @@ func NewUpsertVehicleHeaders(conn database.ConnectionFactory, saveFSMTransition 
 			}
 
 			// Persistir FSMState si está presente
-			if len(fsmState) > 0 {
+			if len(fsmState) > 0 && saveFSMTransition != nil {
 				return saveFSMTransition(ctx, fsmState[0], tx)
 			}
 

--- a/app/adapter/out/tidbrepository/upsert_vehicle_headers_test.go
+++ b/app/adapter/out/tidbrepository/upsert_vehicle_headers_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertVehicleHeaders", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertVehicleHeaders(conn)
+		upsert = NewUpsertVehicleHeaders(conn, nil)
 	})
 
 	It("should insert headers if not exists", func() {
@@ -179,7 +179,7 @@ var _ = Describe("UpsertVehicleHeaders", func() {
 			Channel:  "WEB",
 		}
 
-		upsert := NewUpsertVehicleHeaders(noTablesContainerConnection)
+		upsert := NewUpsertVehicleHeaders(noTablesContainerConnection, nil)
 		err = upsert(ctx, headers)
 
 		Expect(err).To(HaveOccurred())

--- a/app/adapter/out/tidbrepository/upsert_vehicle_test.go
+++ b/app/adapter/out/tidbrepository/upsert_vehicle_test.go
@@ -18,7 +18,7 @@ var _ = Describe("UpsertVehicle", func() {
 
 	BeforeEach(func() {
 		conn = connection
-		upsert = NewUpsertVehicle(conn)
+		upsert = NewUpsertVehicle(conn, nil)
 	})
 
 	It("should insert vehicle if not exists", func() {
@@ -164,7 +164,7 @@ var _ = Describe("UpsertVehicle", func() {
 			},
 		}
 
-		upsert := NewUpsertVehicle(noTablesContainerConnection)
+		upsert := NewUpsertVehicle(noTablesContainerConnection, nil)
 		err = upsert(ctx, vehicle)
 
 		Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Implement FSM pattern across all repositories to enable optional state management.

This PR modifies all repository functions and their corresponding tests to support optional FSM state persistence. It introduces a variadic `...domain.FSMState` parameter, injects `SaveFSMTransition`, and ensures FSM state is saved within the existing transaction only when provided, maintaining backward compatibility.

---

[Open in Web](https://www.cursor.com/agents?id=bc-20813977-5599-4562-94df-aa723be6568e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-20813977-5599-4562-94df-aa723be6568e)