### PR TITLE
Create repository fsm transition workflows

### DIFF
--- a/app/domain/workflows/save_tenant_workflow.go
+++ b/app/domain/workflows/save_tenant_workflow.go
@@ -69,10 +69,6 @@ func (w SaveTenantWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w SaveTenantWorkflow) TransitionToTenantSaved(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.TenantSaved())
-}
-
 func (w SaveTenantWorkflow) CanTransitionToTenantSaved() bool {
 	return w.fsm.Can(w.TenantSaved())
 }

--- a/app/domain/workflows/save_tenant_workflow.go
+++ b/app/domain/workflows/save_tenant_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type SaveTenantWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewSaveTenantWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewSaveTenantWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (SaveTenantWorkflow, error) {
+	return SaveTenantWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w SaveTenantWorkflow) Restore(ctx context.Context, idempotencyKey string) (SaveTenantWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.SaveTenantStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.TenantSaved(), Src: []string{w.SaveTenantStarted()}, Dst: w.TenantSaved()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w SaveTenantWorkflow) WorkflowName() string {
+	return "save_tenant_workflow"
+}
+
+func (w SaveTenantWorkflow) TenantSaved() string {
+	return "tenant_saved"
+}
+
+func (w SaveTenantWorkflow) SaveTenantStarted() string {
+	return "save_tenant_started"
+}
+
+func (w SaveTenantWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w SaveTenantWorkflow) TransitionToTenantSaved(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.TenantSaved())
+}
+
+func (w SaveTenantWorkflow) CanTransitionToTenantSaved() bool {
+	return w.fsm.Can(w.TenantSaved())
+}
+
+func (w SaveTenantWorkflow) IsTenantSaved() bool {
+	return w.fsm.Current() == w.TenantSaved()
+}
+
+func (w SaveTenantWorkflow) IsSaveTenantStarted() bool {
+	return w.fsm.Current() == w.SaveTenantStarted()
+}
+
+// SetTenantSavedTransition completa el save de tenant
+func (w SaveTenantWorkflow) SetTenantSavedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.TenantSaved())
+}

--- a/app/domain/workflows/upsert_account_workflow.go
+++ b/app/domain/workflows/upsert_account_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertAccountWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertAccountWorkflow) TransitionToAccountUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.AccountUpserted())
-}
-
 func (w UpsertAccountWorkflow) CanTransitionToAccountUpserted() bool {
 	return w.fsm.Can(w.AccountUpserted())
 }

--- a/app/domain/workflows/upsert_account_workflow.go
+++ b/app/domain/workflows/upsert_account_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertAccountWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertAccountWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertAccountWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertAccountWorkflow, error) {
+	return UpsertAccountWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertAccountWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertAccountWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertAccountStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.AccountUpserted(), Src: []string{w.UpsertAccountStarted()}, Dst: w.AccountUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertAccountWorkflow) WorkflowName() string {
+	return "upsert_account_workflow"
+}
+
+func (w UpsertAccountWorkflow) AccountUpserted() string {
+	return "account_upserted"
+}
+
+func (w UpsertAccountWorkflow) UpsertAccountStarted() string {
+	return "upsert_account_started"
+}
+
+func (w UpsertAccountWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertAccountWorkflow) TransitionToAccountUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.AccountUpserted())
+}
+
+func (w UpsertAccountWorkflow) CanTransitionToAccountUpserted() bool {
+	return w.fsm.Can(w.AccountUpserted())
+}
+
+func (w UpsertAccountWorkflow) IsAccountUpserted() bool {
+	return w.fsm.Current() == w.AccountUpserted()
+}
+
+func (w UpsertAccountWorkflow) IsUpsertAccountStarted() bool {
+	return w.fsm.Current() == w.UpsertAccountStarted()
+}
+
+// SetAccountUpsertedTransition completa el upsert de account
+func (w UpsertAccountWorkflow) SetAccountUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.AccountUpserted())
+}

--- a/app/domain/workflows/upsert_address_info_workflow.go
+++ b/app/domain/workflows/upsert_address_info_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertAddressInfoWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertAddressInfoWorkflow) TransitionToAddressInfoUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.AddressInfoUpserted())
-}
-
 func (w UpsertAddressInfoWorkflow) CanTransitionToAddressInfoUpserted() bool {
 	return w.fsm.Can(w.AddressInfoUpserted())
 }

--- a/app/domain/workflows/upsert_carrier_workflow.go
+++ b/app/domain/workflows/upsert_carrier_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertCarrierWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertCarrierWorkflow) TransitionToCarrierUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.CarrierUpserted())
-}
-
 func (w UpsertCarrierWorkflow) CanTransitionToCarrierUpserted() bool {
 	return w.fsm.Can(w.CarrierUpserted())
 }

--- a/app/domain/workflows/upsert_carrier_workflow.go
+++ b/app/domain/workflows/upsert_carrier_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertCarrierWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertCarrierWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertCarrierWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertCarrierWorkflow, error) {
+	return UpsertCarrierWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertCarrierWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertCarrierWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertCarrierStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.CarrierUpserted(), Src: []string{w.UpsertCarrierStarted()}, Dst: w.CarrierUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertCarrierWorkflow) WorkflowName() string {
+	return "upsert_carrier_workflow"
+}
+
+func (w UpsertCarrierWorkflow) CarrierUpserted() string {
+	return "carrier_upserted"
+}
+
+func (w UpsertCarrierWorkflow) UpsertCarrierStarted() string {
+	return "upsert_carrier_started"
+}
+
+func (w UpsertCarrierWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertCarrierWorkflow) TransitionToCarrierUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.CarrierUpserted())
+}
+
+func (w UpsertCarrierWorkflow) CanTransitionToCarrierUpserted() bool {
+	return w.fsm.Can(w.CarrierUpserted())
+}
+
+func (w UpsertCarrierWorkflow) IsCarrierUpserted() bool {
+	return w.fsm.Current() == w.CarrierUpserted()
+}
+
+func (w UpsertCarrierWorkflow) IsUpsertCarrierStarted() bool {
+	return w.fsm.Current() == w.UpsertCarrierStarted()
+}
+
+// SetCarrierUpsertedTransition completa el upsert de carrier
+func (w UpsertCarrierWorkflow) SetCarrierUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.CarrierUpserted())
+}

--- a/app/domain/workflows/upsert_client_credentials_workflow.go
+++ b/app/domain/workflows/upsert_client_credentials_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertClientCredentialsWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertClientCredentialsWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertClientCredentialsWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertClientCredentialsWorkflow, error) {
+	return UpsertClientCredentialsWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertClientCredentialsWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertClientCredentialsWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertClientCredentialsStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.ClientCredentialsUpserted(), Src: []string{w.UpsertClientCredentialsStarted()}, Dst: w.ClientCredentialsUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertClientCredentialsWorkflow) WorkflowName() string {
+	return "upsert_client_credentials_workflow"
+}
+
+func (w UpsertClientCredentialsWorkflow) ClientCredentialsUpserted() string {
+	return "client_credentials_upserted"
+}
+
+func (w UpsertClientCredentialsWorkflow) UpsertClientCredentialsStarted() string {
+	return "upsert_client_credentials_started"
+}
+
+func (w UpsertClientCredentialsWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertClientCredentialsWorkflow) TransitionToClientCredentialsUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.ClientCredentialsUpserted())
+}
+
+func (w UpsertClientCredentialsWorkflow) CanTransitionToClientCredentialsUpserted() bool {
+	return w.fsm.Can(w.ClientCredentialsUpserted())
+}
+
+func (w UpsertClientCredentialsWorkflow) IsClientCredentialsUpserted() bool {
+	return w.fsm.Current() == w.ClientCredentialsUpserted()
+}
+
+func (w UpsertClientCredentialsWorkflow) IsUpsertClientCredentialsStarted() bool {
+	return w.fsm.Current() == w.UpsertClientCredentialsStarted()
+}
+
+// SetClientCredentialsUpsertedTransition completa el upsert de client credentials
+func (w UpsertClientCredentialsWorkflow) SetClientCredentialsUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.ClientCredentialsUpserted())
+}

--- a/app/domain/workflows/upsert_client_credentials_workflow.go
+++ b/app/domain/workflows/upsert_client_credentials_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertClientCredentialsWorkflow) Map(ctx context.Context) domain.FSMStat
 	}
 }
 
-func (w UpsertClientCredentialsWorkflow) TransitionToClientCredentialsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.ClientCredentialsUpserted())
-}
-
 func (w UpsertClientCredentialsWorkflow) CanTransitionToClientCredentialsUpserted() bool {
 	return w.fsm.Can(w.ClientCredentialsUpserted())
 }

--- a/app/domain/workflows/upsert_contact_workflow.go
+++ b/app/domain/workflows/upsert_contact_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertContactWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertContactWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertContactWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertContactWorkflow, error) {
+	return UpsertContactWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertContactWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertContactWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertContactStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.ContactUpserted(), Src: []string{w.UpsertContactStarted()}, Dst: w.ContactUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertContactWorkflow) WorkflowName() string {
+	return "upsert_contact_workflow"
+}
+
+func (w UpsertContactWorkflow) ContactUpserted() string {
+	return "contact_upserted"
+}
+
+func (w UpsertContactWorkflow) UpsertContactStarted() string {
+	return "upsert_contact_started"
+}
+
+func (w UpsertContactWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertContactWorkflow) TransitionToContactUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.ContactUpserted())
+}
+
+func (w UpsertContactWorkflow) CanTransitionToContactUpserted() bool {
+	return w.fsm.Can(w.ContactUpserted())
+}
+
+func (w UpsertContactWorkflow) IsContactUpserted() bool {
+	return w.fsm.Current() == w.ContactUpserted()
+}
+
+func (w UpsertContactWorkflow) IsUpsertContactStarted() bool {
+	return w.fsm.Current() == w.UpsertContactStarted()
+}
+
+// SetContactUpsertedTransition completa el upsert de contact
+func (w UpsertContactWorkflow) SetContactUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.ContactUpserted())
+}

--- a/app/domain/workflows/upsert_contact_workflow.go
+++ b/app/domain/workflows/upsert_contact_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertContactWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertContactWorkflow) TransitionToContactUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.ContactUpserted())
-}
-
 func (w UpsertContactWorkflow) CanTransitionToContactUpserted() bool {
 	return w.fsm.Can(w.ContactUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_history_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_history_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertDeliveryUnitsHistoryWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertDeliveryUnitsHistoryWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertDeliveryUnitsHistoryWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertDeliveryUnitsHistoryWorkflow, error) {
+	return UpsertDeliveryUnitsHistoryWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertDeliveryUnitsHistoryWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertDeliveryUnitsHistoryStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.DeliveryUnitsHistoryUpserted(), Src: []string{w.UpsertDeliveryUnitsHistoryStarted()}, Dst: w.DeliveryUnitsHistoryUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) WorkflowName() string {
+	return "upsert_delivery_units_history_workflow"
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) DeliveryUnitsHistoryUpserted() string {
+	return "delivery_units_history_upserted"
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) UpsertDeliveryUnitsHistoryStarted() string {
+	return "upsert_delivery_units_history_started"
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) TransitionToDeliveryUnitsHistoryUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DeliveryUnitsHistoryUpserted())
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) CanTransitionToDeliveryUnitsHistoryUpserted() bool {
+	return w.fsm.Can(w.DeliveryUnitsHistoryUpserted())
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) IsDeliveryUnitsHistoryUpserted() bool {
+	return w.fsm.Current() == w.DeliveryUnitsHistoryUpserted()
+}
+
+func (w UpsertDeliveryUnitsHistoryWorkflow) IsUpsertDeliveryUnitsHistoryStarted() bool {
+	return w.fsm.Current() == w.UpsertDeliveryUnitsHistoryStarted()
+}
+
+// SetDeliveryUnitsHistoryUpsertedTransition completa el upsert de delivery units history
+func (w UpsertDeliveryUnitsHistoryWorkflow) SetDeliveryUnitsHistoryUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DeliveryUnitsHistoryUpserted())
+}

--- a/app/domain/workflows/upsert_delivery_units_history_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_history_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDeliveryUnitsHistoryWorkflow) Map(ctx context.Context) domain.FSMS
 	}
 }
 
-func (w UpsertDeliveryUnitsHistoryWorkflow) TransitionToDeliveryUnitsHistoryUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DeliveryUnitsHistoryUpserted())
-}
-
 func (w UpsertDeliveryUnitsHistoryWorkflow) CanTransitionToDeliveryUnitsHistoryUpserted() bool {
 	return w.fsm.Can(w.DeliveryUnitsHistoryUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_labels_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_labels_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDeliveryUnitsLabelsWorkflow) Map(ctx context.Context) domain.FSMSt
 	}
 }
 
-func (w UpsertDeliveryUnitsLabelsWorkflow) TransitionToDeliveryUnitsLabelsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DeliveryUnitsLabelsUpserted())
-}
-
 func (w UpsertDeliveryUnitsLabelsWorkflow) CanTransitionToDeliveryUnitsLabelsUpserted() bool {
 	return w.fsm.Can(w.DeliveryUnitsLabelsUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_labels_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_labels_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertDeliveryUnitsLabelsWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertDeliveryUnitsLabelsWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertDeliveryUnitsLabelsWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertDeliveryUnitsLabelsWorkflow, error) {
+	return UpsertDeliveryUnitsLabelsWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertDeliveryUnitsLabelsWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertDeliveryUnitsLabelsStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.DeliveryUnitsLabelsUpserted(), Src: []string{w.UpsertDeliveryUnitsLabelsStarted()}, Dst: w.DeliveryUnitsLabelsUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) WorkflowName() string {
+	return "upsert_delivery_units_labels_workflow"
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) DeliveryUnitsLabelsUpserted() string {
+	return "delivery_units_labels_upserted"
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) UpsertDeliveryUnitsLabelsStarted() string {
+	return "upsert_delivery_units_labels_started"
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) TransitionToDeliveryUnitsLabelsUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DeliveryUnitsLabelsUpserted())
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) CanTransitionToDeliveryUnitsLabelsUpserted() bool {
+	return w.fsm.Can(w.DeliveryUnitsLabelsUpserted())
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) IsDeliveryUnitsLabelsUpserted() bool {
+	return w.fsm.Current() == w.DeliveryUnitsLabelsUpserted()
+}
+
+func (w UpsertDeliveryUnitsLabelsWorkflow) IsUpsertDeliveryUnitsLabelsStarted() bool {
+	return w.fsm.Current() == w.UpsertDeliveryUnitsLabelsStarted()
+}
+
+// SetDeliveryUnitsLabelsUpsertedTransition completa el upsert de delivery units labels
+func (w UpsertDeliveryUnitsLabelsWorkflow) SetDeliveryUnitsLabelsUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DeliveryUnitsLabelsUpserted())
+}

--- a/app/domain/workflows/upsert_delivery_units_skills_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_skills_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDeliveryUnitsSkillsWorkflow) Map(ctx context.Context) domain.FSMSt
 	}
 }
 
-func (w UpsertDeliveryUnitsSkillsWorkflow) TransitionToDeliveryUnitsSkillsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DeliveryUnitsSkillsUpserted())
-}
-
 func (w UpsertDeliveryUnitsSkillsWorkflow) CanTransitionToDeliveryUnitsSkillsUpserted() bool {
 	return w.fsm.Can(w.DeliveryUnitsSkillsUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_skills_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_skills_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertDeliveryUnitsSkillsWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertDeliveryUnitsSkillsWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertDeliveryUnitsSkillsWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertDeliveryUnitsSkillsWorkflow, error) {
+	return UpsertDeliveryUnitsSkillsWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertDeliveryUnitsSkillsWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertDeliveryUnitsSkillsStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.DeliveryUnitsSkillsUpserted(), Src: []string{w.UpsertDeliveryUnitsSkillsStarted()}, Dst: w.DeliveryUnitsSkillsUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) WorkflowName() string {
+	return "upsert_delivery_units_skills_workflow"
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) DeliveryUnitsSkillsUpserted() string {
+	return "delivery_units_skills_upserted"
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) UpsertDeliveryUnitsSkillsStarted() string {
+	return "upsert_delivery_units_skills_started"
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) TransitionToDeliveryUnitsSkillsUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DeliveryUnitsSkillsUpserted())
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) CanTransitionToDeliveryUnitsSkillsUpserted() bool {
+	return w.fsm.Can(w.DeliveryUnitsSkillsUpserted())
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) IsDeliveryUnitsSkillsUpserted() bool {
+	return w.fsm.Current() == w.DeliveryUnitsSkillsUpserted()
+}
+
+func (w UpsertDeliveryUnitsSkillsWorkflow) IsUpsertDeliveryUnitsSkillsStarted() bool {
+	return w.fsm.Current() == w.UpsertDeliveryUnitsSkillsStarted()
+}
+
+// SetDeliveryUnitsSkillsUpsertedTransition completa el upsert de delivery units skills
+func (w UpsertDeliveryUnitsSkillsWorkflow) SetDeliveryUnitsSkillsUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DeliveryUnitsSkillsUpserted())
+}

--- a/app/domain/workflows/upsert_delivery_units_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDeliveryUnitsWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertDeliveryUnitsWorkflow) TransitionToDeliveryUnitsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DeliveryUnitsUpserted())
-}
-
 func (w UpsertDeliveryUnitsWorkflow) CanTransitionToDeliveryUnitsUpserted() bool {
 	return w.fsm.Can(w.DeliveryUnitsUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertDeliveryUnitsWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertDeliveryUnitsWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertDeliveryUnitsWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertDeliveryUnitsWorkflow, error) {
+	return UpsertDeliveryUnitsWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertDeliveryUnitsWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertDeliveryUnitsWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertDeliveryUnitsStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.DeliveryUnitsUpserted(), Src: []string{w.UpsertDeliveryUnitsStarted()}, Dst: w.DeliveryUnitsUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertDeliveryUnitsWorkflow) WorkflowName() string {
+	return "upsert_delivery_units_workflow"
+}
+
+func (w UpsertDeliveryUnitsWorkflow) DeliveryUnitsUpserted() string {
+	return "delivery_units_upserted"
+}
+
+func (w UpsertDeliveryUnitsWorkflow) UpsertDeliveryUnitsStarted() string {
+	return "upsert_delivery_units_started"
+}
+
+func (w UpsertDeliveryUnitsWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertDeliveryUnitsWorkflow) TransitionToDeliveryUnitsUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DeliveryUnitsUpserted())
+}
+
+func (w UpsertDeliveryUnitsWorkflow) CanTransitionToDeliveryUnitsUpserted() bool {
+	return w.fsm.Can(w.DeliveryUnitsUpserted())
+}
+
+func (w UpsertDeliveryUnitsWorkflow) IsDeliveryUnitsUpserted() bool {
+	return w.fsm.Current() == w.DeliveryUnitsUpserted()
+}
+
+func (w UpsertDeliveryUnitsWorkflow) IsUpsertDeliveryUnitsStarted() bool {
+	return w.fsm.Current() == w.UpsertDeliveryUnitsStarted()
+}
+
+// SetDeliveryUnitsUpsertedTransition completa el upsert de delivery units
+func (w UpsertDeliveryUnitsWorkflow) SetDeliveryUnitsUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DeliveryUnitsUpserted())
+}

--- a/app/domain/workflows/upsert_driver_workflow.go
+++ b/app/domain/workflows/upsert_driver_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertDriverWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertDriverWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertDriverWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertDriverWorkflow, error) {
+	return UpsertDriverWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertDriverWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertDriverWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertDriverStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.DriverUpserted(), Src: []string{w.UpsertDriverStarted()}, Dst: w.DriverUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertDriverWorkflow) WorkflowName() string {
+	return "upsert_driver_workflow"
+}
+
+func (w UpsertDriverWorkflow) DriverUpserted() string {
+	return "driver_upserted"
+}
+
+func (w UpsertDriverWorkflow) UpsertDriverStarted() string {
+	return "upsert_driver_started"
+}
+
+func (w UpsertDriverWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertDriverWorkflow) TransitionToDriverUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DriverUpserted())
+}
+
+func (w UpsertDriverWorkflow) CanTransitionToDriverUpserted() bool {
+	return w.fsm.Can(w.DriverUpserted())
+}
+
+func (w UpsertDriverWorkflow) IsDriverUpserted() bool {
+	return w.fsm.Current() == w.DriverUpserted()
+}
+
+func (w UpsertDriverWorkflow) IsUpsertDriverStarted() bool {
+	return w.fsm.Current() == w.UpsertDriverStarted()
+}
+
+// SetDriverUpsertedTransition completa el upsert de driver
+func (w UpsertDriverWorkflow) SetDriverUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.DriverUpserted())
+}

--- a/app/domain/workflows/upsert_driver_workflow.go
+++ b/app/domain/workflows/upsert_driver_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDriverWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertDriverWorkflow) TransitionToDriverUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DriverUpserted())
-}
-
 func (w UpsertDriverWorkflow) CanTransitionToDriverUpserted() bool {
 	return w.fsm.Can(w.DriverUpserted())
 }

--- a/app/domain/workflows/upsert_node_info_headers_workflow.go
+++ b/app/domain/workflows/upsert_node_info_headers_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertNodeInfoHeadersWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertNodeInfoHeadersWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertNodeInfoHeadersWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertNodeInfoHeadersWorkflow, error) {
+	return UpsertNodeInfoHeadersWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertNodeInfoHeadersWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertNodeInfoHeadersStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.NodeInfoHeadersUpserted(), Src: []string{w.UpsertNodeInfoHeadersStarted()}, Dst: w.NodeInfoHeadersUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) WorkflowName() string {
+	return "upsert_node_info_headers_workflow"
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) NodeInfoHeadersUpserted() string {
+	return "node_info_headers_upserted"
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) UpsertNodeInfoHeadersStarted() string {
+	return "upsert_node_info_headers_started"
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) TransitionToNodeInfoHeadersUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NodeInfoHeadersUpserted())
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) CanTransitionToNodeInfoHeadersUpserted() bool {
+	return w.fsm.Can(w.NodeInfoHeadersUpserted())
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) IsNodeInfoHeadersUpserted() bool {
+	return w.fsm.Current() == w.NodeInfoHeadersUpserted()
+}
+
+func (w UpsertNodeInfoHeadersWorkflow) IsUpsertNodeInfoHeadersStarted() bool {
+	return w.fsm.Current() == w.UpsertNodeInfoHeadersStarted()
+}
+
+// SetNodeInfoHeadersUpsertedTransition completa el upsert de node info headers
+func (w UpsertNodeInfoHeadersWorkflow) SetNodeInfoHeadersUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NodeInfoHeadersUpserted())
+}

--- a/app/domain/workflows/upsert_node_info_headers_workflow.go
+++ b/app/domain/workflows/upsert_node_info_headers_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNodeInfoHeadersWorkflow) Map(ctx context.Context) domain.FSMState 
 	}
 }
 
-func (w UpsertNodeInfoHeadersWorkflow) TransitionToNodeInfoHeadersUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NodeInfoHeadersUpserted())
-}
-
 func (w UpsertNodeInfoHeadersWorkflow) CanTransitionToNodeInfoHeadersUpserted() bool {
 	return w.fsm.Can(w.NodeInfoHeadersUpserted())
 }

--- a/app/domain/workflows/upsert_node_info_workflow.go
+++ b/app/domain/workflows/upsert_node_info_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNodeInfoWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertNodeInfoWorkflow) TransitionToNodeInfoUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NodeInfoUpserted())
-}
-
 func (w UpsertNodeInfoWorkflow) CanTransitionToNodeInfoUpserted() bool {
 	return w.fsm.Can(w.NodeInfoUpserted())
 }

--- a/app/domain/workflows/upsert_node_info_workflow.go
+++ b/app/domain/workflows/upsert_node_info_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertNodeInfoWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertNodeInfoWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertNodeInfoWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertNodeInfoWorkflow, error) {
+	return UpsertNodeInfoWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertNodeInfoWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertNodeInfoWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertNodeInfoStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.NodeInfoUpserted(), Src: []string{w.UpsertNodeInfoStarted()}, Dst: w.NodeInfoUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertNodeInfoWorkflow) WorkflowName() string {
+	return "upsert_node_info_workflow"
+}
+
+func (w UpsertNodeInfoWorkflow) NodeInfoUpserted() string {
+	return "node_info_upserted"
+}
+
+func (w UpsertNodeInfoWorkflow) UpsertNodeInfoStarted() string {
+	return "upsert_node_info_started"
+}
+
+func (w UpsertNodeInfoWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertNodeInfoWorkflow) TransitionToNodeInfoUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NodeInfoUpserted())
+}
+
+func (w UpsertNodeInfoWorkflow) CanTransitionToNodeInfoUpserted() bool {
+	return w.fsm.Can(w.NodeInfoUpserted())
+}
+
+func (w UpsertNodeInfoWorkflow) IsNodeInfoUpserted() bool {
+	return w.fsm.Current() == w.NodeInfoUpserted()
+}
+
+func (w UpsertNodeInfoWorkflow) IsUpsertNodeInfoStarted() bool {
+	return w.fsm.Current() == w.UpsertNodeInfoStarted()
+}
+
+// SetNodeInfoUpsertedTransition completa el upsert de node info
+func (w UpsertNodeInfoWorkflow) SetNodeInfoUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NodeInfoUpserted())
+}

--- a/app/domain/workflows/upsert_node_references_workflow.go
+++ b/app/domain/workflows/upsert_node_references_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNodeReferencesWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertNodeReferencesWorkflow) TransitionToNodeReferencesUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NodeReferencesUpserted())
-}
-
 func (w UpsertNodeReferencesWorkflow) CanTransitionToNodeReferencesUpserted() bool {
 	return w.fsm.Can(w.NodeReferencesUpserted())
 }

--- a/app/domain/workflows/upsert_node_references_workflow.go
+++ b/app/domain/workflows/upsert_node_references_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertNodeReferencesWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertNodeReferencesWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertNodeReferencesWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertNodeReferencesWorkflow, error) {
+	return UpsertNodeReferencesWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertNodeReferencesWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertNodeReferencesWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertNodeReferencesStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.NodeReferencesUpserted(), Src: []string{w.UpsertNodeReferencesStarted()}, Dst: w.NodeReferencesUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertNodeReferencesWorkflow) WorkflowName() string {
+	return "upsert_node_references_workflow"
+}
+
+func (w UpsertNodeReferencesWorkflow) NodeReferencesUpserted() string {
+	return "node_references_upserted"
+}
+
+func (w UpsertNodeReferencesWorkflow) UpsertNodeReferencesStarted() string {
+	return "upsert_node_references_started"
+}
+
+func (w UpsertNodeReferencesWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertNodeReferencesWorkflow) TransitionToNodeReferencesUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NodeReferencesUpserted())
+}
+
+func (w UpsertNodeReferencesWorkflow) CanTransitionToNodeReferencesUpserted() bool {
+	return w.fsm.Can(w.NodeReferencesUpserted())
+}
+
+func (w UpsertNodeReferencesWorkflow) IsNodeReferencesUpserted() bool {
+	return w.fsm.Current() == w.NodeReferencesUpserted()
+}
+
+func (w UpsertNodeReferencesWorkflow) IsUpsertNodeReferencesStarted() bool {
+	return w.fsm.Current() == w.UpsertNodeReferencesStarted()
+}
+
+// SetNodeReferencesUpsertedTransition completa el upsert de node references
+func (w UpsertNodeReferencesWorkflow) SetNodeReferencesUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NodeReferencesUpserted())
+}

--- a/app/domain/workflows/upsert_node_type_workflow.go
+++ b/app/domain/workflows/upsert_node_type_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertNodeTypeWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertNodeTypeWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertNodeTypeWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertNodeTypeWorkflow, error) {
+	return UpsertNodeTypeWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertNodeTypeWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertNodeTypeWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertNodeTypeStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.NodeTypeUpserted(), Src: []string{w.UpsertNodeTypeStarted()}, Dst: w.NodeTypeUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertNodeTypeWorkflow) WorkflowName() string {
+	return "upsert_node_type_workflow"
+}
+
+func (w UpsertNodeTypeWorkflow) NodeTypeUpserted() string {
+	return "node_type_upserted"
+}
+
+func (w UpsertNodeTypeWorkflow) UpsertNodeTypeStarted() string {
+	return "upsert_node_type_started"
+}
+
+func (w UpsertNodeTypeWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertNodeTypeWorkflow) TransitionToNodeTypeUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NodeTypeUpserted())
+}
+
+func (w UpsertNodeTypeWorkflow) CanTransitionToNodeTypeUpserted() bool {
+	return w.fsm.Can(w.NodeTypeUpserted())
+}
+
+func (w UpsertNodeTypeWorkflow) IsNodeTypeUpserted() bool {
+	return w.fsm.Current() == w.NodeTypeUpserted()
+}
+
+func (w UpsertNodeTypeWorkflow) IsUpsertNodeTypeStarted() bool {
+	return w.fsm.Current() == w.UpsertNodeTypeStarted()
+}
+
+// SetNodeTypeUpsertedTransition completa el upsert de node type
+func (w UpsertNodeTypeWorkflow) SetNodeTypeUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NodeTypeUpserted())
+}

--- a/app/domain/workflows/upsert_node_type_workflow.go
+++ b/app/domain/workflows/upsert_node_type_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNodeTypeWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertNodeTypeWorkflow) TransitionToNodeTypeUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NodeTypeUpserted())
-}
-
 func (w UpsertNodeTypeWorkflow) CanTransitionToNodeTypeUpserted() bool {
 	return w.fsm.Can(w.NodeTypeUpserted())
 }

--- a/app/domain/workflows/upsert_non_delivery_reason_workflow.go
+++ b/app/domain/workflows/upsert_non_delivery_reason_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNonDeliveryReasonWorkflow) Map(ctx context.Context) domain.FSMStat
 	}
 }
 
-func (w UpsertNonDeliveryReasonWorkflow) TransitionToNonDeliveryReasonUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NonDeliveryReasonUpserted())
-}
-
 func (w UpsertNonDeliveryReasonWorkflow) CanTransitionToNonDeliveryReasonUpserted() bool {
 	return w.fsm.Can(w.NonDeliveryReasonUpserted())
 }

--- a/app/domain/workflows/upsert_non_delivery_reason_workflow.go
+++ b/app/domain/workflows/upsert_non_delivery_reason_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertNonDeliveryReasonWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertNonDeliveryReasonWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertNonDeliveryReasonWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertNonDeliveryReasonWorkflow, error) {
+	return UpsertNonDeliveryReasonWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertNonDeliveryReasonWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertNonDeliveryReasonStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.NonDeliveryReasonUpserted(), Src: []string{w.UpsertNonDeliveryReasonStarted()}, Dst: w.NonDeliveryReasonUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) WorkflowName() string {
+	return "upsert_non_delivery_reason_workflow"
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) NonDeliveryReasonUpserted() string {
+	return "non_delivery_reason_upserted"
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) UpsertNonDeliveryReasonStarted() string {
+	return "upsert_non_delivery_reason_started"
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) TransitionToNonDeliveryReasonUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NonDeliveryReasonUpserted())
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) CanTransitionToNonDeliveryReasonUpserted() bool {
+	return w.fsm.Can(w.NonDeliveryReasonUpserted())
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) IsNonDeliveryReasonUpserted() bool {
+	return w.fsm.Current() == w.NonDeliveryReasonUpserted()
+}
+
+func (w UpsertNonDeliveryReasonWorkflow) IsUpsertNonDeliveryReasonStarted() bool {
+	return w.fsm.Current() == w.UpsertNonDeliveryReasonStarted()
+}
+
+// SetNonDeliveryReasonUpsertedTransition completa el upsert de non delivery reason
+func (w UpsertNonDeliveryReasonWorkflow) SetNonDeliveryReasonUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.NonDeliveryReasonUpserted())
+}

--- a/app/domain/workflows/upsert_order_delivery_units_workflow.go
+++ b/app/domain/workflows/upsert_order_delivery_units_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertOrderDeliveryUnitsWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertOrderDeliveryUnitsWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertOrderDeliveryUnitsWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertOrderDeliveryUnitsWorkflow, error) {
+	return UpsertOrderDeliveryUnitsWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertOrderDeliveryUnitsWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertOrderDeliveryUnitsStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.OrderDeliveryUnitsUpserted(), Src: []string{w.UpsertOrderDeliveryUnitsStarted()}, Dst: w.OrderDeliveryUnitsUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) WorkflowName() string {
+	return "upsert_order_delivery_units_workflow"
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) OrderDeliveryUnitsUpserted() string {
+	return "order_delivery_units_upserted"
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) UpsertOrderDeliveryUnitsStarted() string {
+	return "upsert_order_delivery_units_started"
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) TransitionToOrderDeliveryUnitsUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.OrderDeliveryUnitsUpserted())
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) CanTransitionToOrderDeliveryUnitsUpserted() bool {
+	return w.fsm.Can(w.OrderDeliveryUnitsUpserted())
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) IsOrderDeliveryUnitsUpserted() bool {
+	return w.fsm.Current() == w.OrderDeliveryUnitsUpserted()
+}
+
+func (w UpsertOrderDeliveryUnitsWorkflow) IsUpsertOrderDeliveryUnitsStarted() bool {
+	return w.fsm.Current() == w.UpsertOrderDeliveryUnitsStarted()
+}
+
+// SetOrderDeliveryUnitsUpsertedTransition completa el upsert de order delivery units
+func (w UpsertOrderDeliveryUnitsWorkflow) SetOrderDeliveryUnitsUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.OrderDeliveryUnitsUpserted())
+}

--- a/app/domain/workflows/upsert_order_delivery_units_workflow.go
+++ b/app/domain/workflows/upsert_order_delivery_units_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderDeliveryUnitsWorkflow) Map(ctx context.Context) domain.FSMSta
 	}
 }
 
-func (w UpsertOrderDeliveryUnitsWorkflow) TransitionToOrderDeliveryUnitsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderDeliveryUnitsUpserted())
-}
-
 func (w UpsertOrderDeliveryUnitsWorkflow) CanTransitionToOrderDeliveryUnitsUpserted() bool {
 	return w.fsm.Can(w.OrderDeliveryUnitsUpserted())
 }

--- a/app/domain/workflows/upsert_order_headers_workflow.go
+++ b/app/domain/workflows/upsert_order_headers_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertOrderHeadersWorkflow) TransitionToOrderHeadersUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderHeadersUpserted())
-}
-
 func (w UpsertOrderHeadersWorkflow) CanTransitionToOrderHeadersUpserted() bool {
 	return w.fsm.Can(w.OrderHeadersUpserted())
 }

--- a/app/domain/workflows/upsert_order_references_workflow.go
+++ b/app/domain/workflows/upsert_order_references_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderReferencesWorkflow) Map(ctx context.Context) domain.FSMState 
 	}
 }
 
-func (w UpsertOrderReferencesWorkflow) TransitionToOrderReferencesUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderReferencesUpserted())
-}
-
 func (w UpsertOrderReferencesWorkflow) CanTransitionToOrderReferencesUpserted() bool {
 	return w.fsm.Can(w.OrderReferencesUpserted())
 }

--- a/app/domain/workflows/upsert_order_references_workflow.go
+++ b/app/domain/workflows/upsert_order_references_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertOrderReferencesWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertOrderReferencesWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertOrderReferencesWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertOrderReferencesWorkflow, error) {
+	return UpsertOrderReferencesWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertOrderReferencesWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertOrderReferencesWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertOrderReferencesStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.OrderReferencesUpserted(), Src: []string{w.UpsertOrderReferencesStarted()}, Dst: w.OrderReferencesUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertOrderReferencesWorkflow) WorkflowName() string {
+	return "upsert_order_references_workflow"
+}
+
+func (w UpsertOrderReferencesWorkflow) OrderReferencesUpserted() string {
+	return "order_references_upserted"
+}
+
+func (w UpsertOrderReferencesWorkflow) UpsertOrderReferencesStarted() string {
+	return "upsert_order_references_started"
+}
+
+func (w UpsertOrderReferencesWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertOrderReferencesWorkflow) TransitionToOrderReferencesUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.OrderReferencesUpserted())
+}
+
+func (w UpsertOrderReferencesWorkflow) CanTransitionToOrderReferencesUpserted() bool {
+	return w.fsm.Can(w.OrderReferencesUpserted())
+}
+
+func (w UpsertOrderReferencesWorkflow) IsOrderReferencesUpserted() bool {
+	return w.fsm.Current() == w.OrderReferencesUpserted()
+}
+
+func (w UpsertOrderReferencesWorkflow) IsUpsertOrderReferencesStarted() bool {
+	return w.fsm.Current() == w.UpsertOrderReferencesStarted()
+}
+
+// SetOrderReferencesUpsertedTransition completa el upsert de order references
+func (w UpsertOrderReferencesWorkflow) SetOrderReferencesUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.OrderReferencesUpserted())
+}

--- a/app/domain/workflows/upsert_order_type_workflow.go
+++ b/app/domain/workflows/upsert_order_type_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderTypeWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertOrderTypeWorkflow) TransitionToOrderTypeUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderTypeUpserted())
-}
-
 func (w UpsertOrderTypeWorkflow) CanTransitionToOrderTypeUpserted() bool {
 	return w.fsm.Can(w.OrderTypeUpserted())
 }

--- a/app/domain/workflows/upsert_order_type_workflow.go
+++ b/app/domain/workflows/upsert_order_type_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertOrderTypeWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertOrderTypeWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertOrderTypeWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertOrderTypeWorkflow, error) {
+	return UpsertOrderTypeWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertOrderTypeWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertOrderTypeWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertOrderTypeStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.OrderTypeUpserted(), Src: []string{w.UpsertOrderTypeStarted()}, Dst: w.OrderTypeUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertOrderTypeWorkflow) WorkflowName() string {
+	return "upsert_order_type_workflow"
+}
+
+func (w UpsertOrderTypeWorkflow) OrderTypeUpserted() string {
+	return "order_type_upserted"
+}
+
+func (w UpsertOrderTypeWorkflow) UpsertOrderTypeStarted() string {
+	return "upsert_order_type_started"
+}
+
+func (w UpsertOrderTypeWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertOrderTypeWorkflow) TransitionToOrderTypeUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.OrderTypeUpserted())
+}
+
+func (w UpsertOrderTypeWorkflow) CanTransitionToOrderTypeUpserted() bool {
+	return w.fsm.Can(w.OrderTypeUpserted())
+}
+
+func (w UpsertOrderTypeWorkflow) IsOrderTypeUpserted() bool {
+	return w.fsm.Current() == w.OrderTypeUpserted()
+}
+
+func (w UpsertOrderTypeWorkflow) IsUpsertOrderTypeStarted() bool {
+	return w.fsm.Current() == w.UpsertOrderTypeStarted()
+}
+
+// SetOrderTypeUpsertedTransition completa el upsert de order type
+func (w UpsertOrderTypeWorkflow) SetOrderTypeUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.OrderTypeUpserted())
+}

--- a/app/domain/workflows/upsert_order_workflow.go
+++ b/app/domain/workflows/upsert_order_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertOrderWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertOrderWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertOrderWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertOrderWorkflow, error) {
+	return UpsertOrderWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertOrderWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertOrderWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertOrderStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.OrderUpserted(), Src: []string{w.UpsertOrderStarted()}, Dst: w.OrderUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertOrderWorkflow) WorkflowName() string {
+	return "upsert_order_workflow"
+}
+
+func (w UpsertOrderWorkflow) OrderUpserted() string {
+	return "order_upserted"
+}
+
+func (w UpsertOrderWorkflow) UpsertOrderStarted() string {
+	return "upsert_order_started"
+}
+
+func (w UpsertOrderWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertOrderWorkflow) TransitionToOrderUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.OrderUpserted())
+}
+
+func (w UpsertOrderWorkflow) CanTransitionToOrderUpserted() bool {
+	return w.fsm.Can(w.OrderUpserted())
+}
+
+func (w UpsertOrderWorkflow) IsOrderUpserted() bool {
+	return w.fsm.Current() == w.OrderUpserted()
+}
+
+func (w UpsertOrderWorkflow) IsUpsertOrderStarted() bool {
+	return w.fsm.Current() == w.UpsertOrderStarted()
+}
+
+// SetOrderUpsertedTransition completa el upsert de order
+func (w UpsertOrderWorkflow) SetOrderUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.OrderUpserted())
+}

--- a/app/domain/workflows/upsert_order_workflow.go
+++ b/app/domain/workflows/upsert_order_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertOrderWorkflow) TransitionToOrderUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderUpserted())
-}
-
 func (w UpsertOrderWorkflow) CanTransitionToOrderUpserted() bool {
 	return w.fsm.Can(w.OrderUpserted())
 }

--- a/app/domain/workflows/upsert_plan_headers_workflow.go
+++ b/app/domain/workflows/upsert_plan_headers_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertPlanHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertPlanHeadersWorkflow) TransitionToPlanHeadersUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.PlanHeadersUpserted())
-}
-
 func (w UpsertPlanHeadersWorkflow) CanTransitionToPlanHeadersUpserted() bool {
 	return w.fsm.Can(w.PlanHeadersUpserted())
 }

--- a/app/domain/workflows/upsert_plan_headers_workflow.go
+++ b/app/domain/workflows/upsert_plan_headers_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertPlanHeadersWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertPlanHeadersWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertPlanHeadersWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertPlanHeadersWorkflow, error) {
+	return UpsertPlanHeadersWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertPlanHeadersWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertPlanHeadersWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertPlanHeadersStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.PlanHeadersUpserted(), Src: []string{w.UpsertPlanHeadersStarted()}, Dst: w.PlanHeadersUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertPlanHeadersWorkflow) WorkflowName() string {
+	return "upsert_plan_headers_workflow"
+}
+
+func (w UpsertPlanHeadersWorkflow) PlanHeadersUpserted() string {
+	return "plan_headers_upserted"
+}
+
+func (w UpsertPlanHeadersWorkflow) UpsertPlanHeadersStarted() string {
+	return "upsert_plan_headers_started"
+}
+
+func (w UpsertPlanHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertPlanHeadersWorkflow) TransitionToPlanHeadersUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.PlanHeadersUpserted())
+}
+
+func (w UpsertPlanHeadersWorkflow) CanTransitionToPlanHeadersUpserted() bool {
+	return w.fsm.Can(w.PlanHeadersUpserted())
+}
+
+func (w UpsertPlanHeadersWorkflow) IsPlanHeadersUpserted() bool {
+	return w.fsm.Current() == w.PlanHeadersUpserted()
+}
+
+func (w UpsertPlanHeadersWorkflow) IsUpsertPlanHeadersStarted() bool {
+	return w.fsm.Current() == w.UpsertPlanHeadersStarted()
+}
+
+// SetPlanHeadersUpsertedTransition completa el upsert de plan headers
+func (w UpsertPlanHeadersWorkflow) SetPlanHeadersUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.PlanHeadersUpserted())
+}

--- a/app/domain/workflows/upsert_plan_workflow.go
+++ b/app/domain/workflows/upsert_plan_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertPlanWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertPlanWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertPlanWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertPlanWorkflow, error) {
+	return UpsertPlanWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertPlanWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertPlanWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertPlanStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.PlanUpserted(), Src: []string{w.UpsertPlanStarted()}, Dst: w.PlanUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertPlanWorkflow) WorkflowName() string {
+	return "upsert_plan_workflow"
+}
+
+func (w UpsertPlanWorkflow) PlanUpserted() string {
+	return "plan_upserted"
+}
+
+func (w UpsertPlanWorkflow) UpsertPlanStarted() string {
+	return "upsert_plan_started"
+}
+
+func (w UpsertPlanWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertPlanWorkflow) TransitionToPlanUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.PlanUpserted())
+}
+
+func (w UpsertPlanWorkflow) CanTransitionToPlanUpserted() bool {
+	return w.fsm.Can(w.PlanUpserted())
+}
+
+func (w UpsertPlanWorkflow) IsPlanUpserted() bool {
+	return w.fsm.Current() == w.PlanUpserted()
+}
+
+func (w UpsertPlanWorkflow) IsUpsertPlanStarted() bool {
+	return w.fsm.Current() == w.UpsertPlanStarted()
+}
+
+// SetPlanUpsertedTransition completa el upsert de plan
+func (w UpsertPlanWorkflow) SetPlanUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.PlanUpserted())
+}

--- a/app/domain/workflows/upsert_plan_workflow.go
+++ b/app/domain/workflows/upsert_plan_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertPlanWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertPlanWorkflow) TransitionToPlanUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.PlanUpserted())
-}
-
 func (w UpsertPlanWorkflow) CanTransitionToPlanUpserted() bool {
 	return w.fsm.Can(w.PlanUpserted())
 }

--- a/app/domain/workflows/upsert_political_area_workflow.go
+++ b/app/domain/workflows/upsert_political_area_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertPoliticalAreaWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertPoliticalAreaWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertPoliticalAreaWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertPoliticalAreaWorkflow, error) {
+	return UpsertPoliticalAreaWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertPoliticalAreaWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertPoliticalAreaWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertPoliticalAreaStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.PoliticalAreaUpserted(), Src: []string{w.UpsertPoliticalAreaStarted()}, Dst: w.PoliticalAreaUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertPoliticalAreaWorkflow) WorkflowName() string {
+	return "upsert_political_area_workflow"
+}
+
+func (w UpsertPoliticalAreaWorkflow) PoliticalAreaUpserted() string {
+	return "political_area_upserted"
+}
+
+func (w UpsertPoliticalAreaWorkflow) UpsertPoliticalAreaStarted() string {
+	return "upsert_political_area_started"
+}
+
+func (w UpsertPoliticalAreaWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertPoliticalAreaWorkflow) TransitionToPoliticalAreaUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.PoliticalAreaUpserted())
+}
+
+func (w UpsertPoliticalAreaWorkflow) CanTransitionToPoliticalAreaUpserted() bool {
+	return w.fsm.Can(w.PoliticalAreaUpserted())
+}
+
+func (w UpsertPoliticalAreaWorkflow) IsPoliticalAreaUpserted() bool {
+	return w.fsm.Current() == w.PoliticalAreaUpserted()
+}
+
+func (w UpsertPoliticalAreaWorkflow) IsUpsertPoliticalAreaStarted() bool {
+	return w.fsm.Current() == w.UpsertPoliticalAreaStarted()
+}
+
+// SetPoliticalAreaUpsertedTransition completa el upsert de political area
+func (w UpsertPoliticalAreaWorkflow) SetPoliticalAreaUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.PoliticalAreaUpserted())
+}

--- a/app/domain/workflows/upsert_political_area_workflow.go
+++ b/app/domain/workflows/upsert_political_area_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertPoliticalAreaWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertPoliticalAreaWorkflow) TransitionToPoliticalAreaUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.PoliticalAreaUpserted())
-}
-
 func (w UpsertPoliticalAreaWorkflow) CanTransitionToPoliticalAreaUpserted() bool {
 	return w.fsm.Can(w.PoliticalAreaUpserted())
 }

--- a/app/domain/workflows/upsert_route_workflow.go
+++ b/app/domain/workflows/upsert_route_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertRouteWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertRouteWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertRouteWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertRouteWorkflow, error) {
+	return UpsertRouteWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertRouteWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertRouteWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertRouteStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.RouteUpserted(), Src: []string{w.UpsertRouteStarted()}, Dst: w.RouteUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertRouteWorkflow) WorkflowName() string {
+	return "upsert_route_workflow"
+}
+
+func (w UpsertRouteWorkflow) RouteUpserted() string {
+	return "route_upserted"
+}
+
+func (w UpsertRouteWorkflow) UpsertRouteStarted() string {
+	return "upsert_route_started"
+}
+
+func (w UpsertRouteWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertRouteWorkflow) TransitionToRouteUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.RouteUpserted())
+}
+
+func (w UpsertRouteWorkflow) CanTransitionToRouteUpserted() bool {
+	return w.fsm.Can(w.RouteUpserted())
+}
+
+func (w UpsertRouteWorkflow) IsRouteUpserted() bool {
+	return w.fsm.Current() == w.RouteUpserted()
+}
+
+func (w UpsertRouteWorkflow) IsUpsertRouteStarted() bool {
+	return w.fsm.Current() == w.UpsertRouteStarted()
+}
+
+// SetRouteUpsertedTransition completa el upsert de route
+func (w UpsertRouteWorkflow) SetRouteUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.RouteUpserted())
+}

--- a/app/domain/workflows/upsert_route_workflow.go
+++ b/app/domain/workflows/upsert_route_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertRouteWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertRouteWorkflow) TransitionToRouteUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.RouteUpserted())
-}
-
 func (w UpsertRouteWorkflow) CanTransitionToRouteUpserted() bool {
 	return w.fsm.Can(w.RouteUpserted())
 }

--- a/app/domain/workflows/upsert_size_category_workflow.go
+++ b/app/domain/workflows/upsert_size_category_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertSizeCategoryWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertSizeCategoryWorkflow) TransitionToSizeCategoryUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.SizeCategoryUpserted())
-}
-
 func (w UpsertSizeCategoryWorkflow) CanTransitionToSizeCategoryUpserted() bool {
 	return w.fsm.Can(w.SizeCategoryUpserted())
 }

--- a/app/domain/workflows/upsert_size_category_workflow.go
+++ b/app/domain/workflows/upsert_size_category_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertSizeCategoryWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertSizeCategoryWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertSizeCategoryWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertSizeCategoryWorkflow, error) {
+	return UpsertSizeCategoryWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertSizeCategoryWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertSizeCategoryWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertSizeCategoryStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.SizeCategoryUpserted(), Src: []string{w.UpsertSizeCategoryStarted()}, Dst: w.SizeCategoryUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertSizeCategoryWorkflow) WorkflowName() string {
+	return "upsert_size_category_workflow"
+}
+
+func (w UpsertSizeCategoryWorkflow) SizeCategoryUpserted() string {
+	return "size_category_upserted"
+}
+
+func (w UpsertSizeCategoryWorkflow) UpsertSizeCategoryStarted() string {
+	return "upsert_size_category_started"
+}
+
+func (w UpsertSizeCategoryWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertSizeCategoryWorkflow) TransitionToSizeCategoryUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.SizeCategoryUpserted())
+}
+
+func (w UpsertSizeCategoryWorkflow) CanTransitionToSizeCategoryUpserted() bool {
+	return w.fsm.Can(w.SizeCategoryUpserted())
+}
+
+func (w UpsertSizeCategoryWorkflow) IsSizeCategoryUpserted() bool {
+	return w.fsm.Current() == w.SizeCategoryUpserted()
+}
+
+func (w UpsertSizeCategoryWorkflow) IsUpsertSizeCategoryStarted() bool {
+	return w.fsm.Current() == w.UpsertSizeCategoryStarted()
+}
+
+// SetSizeCategoryUpsertedTransition completa el upsert de size category
+func (w UpsertSizeCategoryWorkflow) SetSizeCategoryUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.SizeCategoryUpserted())
+}

--- a/app/domain/workflows/upsert_skill_workflow.go
+++ b/app/domain/workflows/upsert_skill_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertSkillWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertSkillWorkflow) TransitionToSkillUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.SkillUpserted())
-}
-
 func (w UpsertSkillWorkflow) CanTransitionToSkillUpserted() bool {
 	return w.fsm.Can(w.SkillUpserted())
 }

--- a/app/domain/workflows/upsert_skill_workflow.go
+++ b/app/domain/workflows/upsert_skill_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertSkillWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertSkillWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertSkillWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertSkillWorkflow, error) {
+	return UpsertSkillWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertSkillWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertSkillWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertSkillStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.SkillUpserted(), Src: []string{w.UpsertSkillStarted()}, Dst: w.SkillUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertSkillWorkflow) WorkflowName() string {
+	return "upsert_skill_workflow"
+}
+
+func (w UpsertSkillWorkflow) SkillUpserted() string {
+	return "skill_upserted"
+}
+
+func (w UpsertSkillWorkflow) UpsertSkillStarted() string {
+	return "upsert_skill_started"
+}
+
+func (w UpsertSkillWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertSkillWorkflow) TransitionToSkillUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.SkillUpserted())
+}
+
+func (w UpsertSkillWorkflow) CanTransitionToSkillUpserted() bool {
+	return w.fsm.Can(w.SkillUpserted())
+}
+
+func (w UpsertSkillWorkflow) IsSkillUpserted() bool {
+	return w.fsm.Current() == w.SkillUpserted()
+}
+
+func (w UpsertSkillWorkflow) IsUpsertSkillStarted() bool {
+	return w.fsm.Current() == w.UpsertSkillStarted()
+}
+
+// SetSkillUpsertedTransition completa el upsert de skill
+func (w UpsertSkillWorkflow) SetSkillUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.SkillUpserted())
+}

--- a/app/domain/workflows/upsert_vehicle_category_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_category_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertVehicleCategoryWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertVehicleCategoryWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertVehicleCategoryWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertVehicleCategoryWorkflow, error) {
+	return UpsertVehicleCategoryWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertVehicleCategoryWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertVehicleCategoryWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertVehicleCategoryStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.VehicleCategoryUpserted(), Src: []string{w.UpsertVehicleCategoryStarted()}, Dst: w.VehicleCategoryUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertVehicleCategoryWorkflow) WorkflowName() string {
+	return "upsert_vehicle_category_workflow"
+}
+
+func (w UpsertVehicleCategoryWorkflow) VehicleCategoryUpserted() string {
+	return "vehicle_category_upserted"
+}
+
+func (w UpsertVehicleCategoryWorkflow) UpsertVehicleCategoryStarted() string {
+	return "upsert_vehicle_category_started"
+}
+
+func (w UpsertVehicleCategoryWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertVehicleCategoryWorkflow) TransitionToVehicleCategoryUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.VehicleCategoryUpserted())
+}
+
+func (w UpsertVehicleCategoryWorkflow) CanTransitionToVehicleCategoryUpserted() bool {
+	return w.fsm.Can(w.VehicleCategoryUpserted())
+}
+
+func (w UpsertVehicleCategoryWorkflow) IsVehicleCategoryUpserted() bool {
+	return w.fsm.Current() == w.VehicleCategoryUpserted()
+}
+
+func (w UpsertVehicleCategoryWorkflow) IsUpsertVehicleCategoryStarted() bool {
+	return w.fsm.Current() == w.UpsertVehicleCategoryStarted()
+}
+
+// SetVehicleCategoryUpsertedTransition completa el upsert de vehicle category
+func (w UpsertVehicleCategoryWorkflow) SetVehicleCategoryUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.VehicleCategoryUpserted())
+}

--- a/app/domain/workflows/upsert_vehicle_category_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_category_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertVehicleCategoryWorkflow) Map(ctx context.Context) domain.FSMState 
 	}
 }
 
-func (w UpsertVehicleCategoryWorkflow) TransitionToVehicleCategoryUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.VehicleCategoryUpserted())
-}
-
 func (w UpsertVehicleCategoryWorkflow) CanTransitionToVehicleCategoryUpserted() bool {
 	return w.fsm.Can(w.VehicleCategoryUpserted())
 }

--- a/app/domain/workflows/upsert_vehicle_headers_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_headers_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertVehicleHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertVehicleHeadersWorkflow) TransitionToVehicleHeadersUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.VehicleHeadersUpserted())
-}
-
 func (w UpsertVehicleHeadersWorkflow) CanTransitionToVehicleHeadersUpserted() bool {
 	return w.fsm.Can(w.VehicleHeadersUpserted())
 }

--- a/app/domain/workflows/upsert_vehicle_headers_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_headers_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertVehicleHeadersWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertVehicleHeadersWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertVehicleHeadersWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertVehicleHeadersWorkflow, error) {
+	return UpsertVehicleHeadersWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertVehicleHeadersWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertVehicleHeadersWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertVehicleHeadersStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.VehicleHeadersUpserted(), Src: []string{w.UpsertVehicleHeadersStarted()}, Dst: w.VehicleHeadersUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertVehicleHeadersWorkflow) WorkflowName() string {
+	return "upsert_vehicle_headers_workflow"
+}
+
+func (w UpsertVehicleHeadersWorkflow) VehicleHeadersUpserted() string {
+	return "vehicle_headers_upserted"
+}
+
+func (w UpsertVehicleHeadersWorkflow) UpsertVehicleHeadersStarted() string {
+	return "upsert_vehicle_headers_started"
+}
+
+func (w UpsertVehicleHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertVehicleHeadersWorkflow) TransitionToVehicleHeadersUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.VehicleHeadersUpserted())
+}
+
+func (w UpsertVehicleHeadersWorkflow) CanTransitionToVehicleHeadersUpserted() bool {
+	return w.fsm.Can(w.VehicleHeadersUpserted())
+}
+
+func (w UpsertVehicleHeadersWorkflow) IsVehicleHeadersUpserted() bool {
+	return w.fsm.Current() == w.VehicleHeadersUpserted()
+}
+
+func (w UpsertVehicleHeadersWorkflow) IsUpsertVehicleHeadersStarted() bool {
+	return w.fsm.Current() == w.UpsertVehicleHeadersStarted()
+}
+
+// SetVehicleHeadersUpsertedTransition completa el upsert de vehicle headers
+func (w UpsertVehicleHeadersWorkflow) SetVehicleHeadersUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.VehicleHeadersUpserted())
+}

--- a/app/domain/workflows/upsert_vehicle_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertVehicleWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertVehicleWorkflow) TransitionToVehicleUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.VehicleUpserted())
-}
-
 func (w UpsertVehicleWorkflow) CanTransitionToVehicleUpserted() bool {
 	return w.fsm.Can(w.VehicleUpserted())
 }

--- a/app/domain/workflows/upsert_vehicle_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_workflow.go
@@ -1,0 +1,91 @@
+package workflows
+
+import (
+	"context"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+	"github.com/looplab/fsm"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type UpsertVehicleWorkflow struct {
+	IdempotencyKey       string
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey
+	fsm                  *fsm.FSM
+}
+
+func init() {
+	ioc.Registry(NewUpsertVehicleWorkflow,
+		tidbrepository.NewGetLastFSMTransitionByIdempotencyKey)
+}
+
+func NewUpsertVehicleWorkflow(
+	getLastFSMTransition tidbrepository.GetLastFSMTransitionByIdempotencyKey) (UpsertVehicleWorkflow, error) {
+	return UpsertVehicleWorkflow{
+		getLastFSMTransition: getLastFSMTransition,
+	}, nil
+}
+
+func (w UpsertVehicleWorkflow) Restore(ctx context.Context, idempotencyKey string) (UpsertVehicleWorkflow, error) {
+	lastTransition, err := w.getLastFSMTransition(ctx, idempotencyKey, w.WorkflowName())
+	w.IdempotencyKey = idempotencyKey
+	if err != nil {
+		return w, err
+	}
+	transition := lastTransition.State
+	if transition == "" {
+		transition = w.UpsertVehicleStarted()
+	}
+	w.fsm = fsm.NewFSM(
+		transition,
+		fsm.Events{
+			{Name: w.VehicleUpserted(), Src: []string{w.UpsertVehicleStarted()}, Dst: w.VehicleUpserted()},
+		},
+		fsm.Callbacks{},
+	)
+	return w, nil
+}
+
+func (w UpsertVehicleWorkflow) WorkflowName() string {
+	return "upsert_vehicle_workflow"
+}
+
+func (w UpsertVehicleWorkflow) VehicleUpserted() string {
+	return "vehicle_upserted"
+}
+
+func (w UpsertVehicleWorkflow) UpsertVehicleStarted() string {
+	return "upsert_vehicle_started"
+}
+
+func (w UpsertVehicleWorkflow) Map(ctx context.Context) domain.FSMState {
+	return domain.FSMState{
+		Workflow:       w.WorkflowName(),
+		TraceID:        trace.SpanContextFromContext(ctx).TraceID().String(),
+		IdempotencyKey: w.IdempotencyKey,
+		State:          w.fsm.Current(),
+	}
+}
+
+func (w UpsertVehicleWorkflow) TransitionToVehicleUpserted(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.VehicleUpserted())
+}
+
+func (w UpsertVehicleWorkflow) CanTransitionToVehicleUpserted() bool {
+	return w.fsm.Can(w.VehicleUpserted())
+}
+
+func (w UpsertVehicleWorkflow) IsVehicleUpserted() bool {
+	return w.fsm.Current() == w.VehicleUpserted()
+}
+
+func (w UpsertVehicleWorkflow) IsUpsertVehicleStarted() bool {
+	return w.fsm.Current() == w.UpsertVehicleStarted()
+}
+
+// SetVehicleUpsertedTransition completa el upsert de vehicle
+func (w UpsertVehicleWorkflow) SetVehicleUpsertedTransition(ctx context.Context) error {
+	return w.fsm.Event(ctx, w.VehicleUpserted())
+}


### PR DESCRIPTION
Add 28 new FSM workflow files to standardize state transition management for repositories using `SaveFSMTransition`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-3d4fccb4-4fca-48e0-b081-eb089d196bf5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3d4fccb4-4fca-48e0-b081-eb089d196bf5)