### PR TITLE
Remove duplicate workflow upsert methods

### DIFF
--- a/app/domain/workflows/upsert_account_workflow.go
+++ b/app/domain/workflows/upsert_account_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertAccountWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertAccountWorkflow) TransitionToAccountUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.AccountUpserted())
-}
-
 func (w UpsertAccountWorkflow) CanTransitionToAccountUpserted() bool {
 	return w.fsm.Can(w.AccountUpserted())
 }

--- a/app/domain/workflows/upsert_address_info_workflow.go
+++ b/app/domain/workflows/upsert_address_info_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertAddressInfoWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertAddressInfoWorkflow) TransitionToAddressInfoUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.AddressInfoUpserted())
-}
-
 func (w UpsertAddressInfoWorkflow) CanTransitionToAddressInfoUpserted() bool {
 	return w.fsm.Can(w.AddressInfoUpserted())
 }

--- a/app/domain/workflows/upsert_carrier_workflow.go
+++ b/app/domain/workflows/upsert_carrier_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertCarrierWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertCarrierWorkflow) TransitionToCarrierUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.CarrierUpserted())
-}
-
 func (w UpsertCarrierWorkflow) CanTransitionToCarrierUpserted() bool {
 	return w.fsm.Can(w.CarrierUpserted())
 }

--- a/app/domain/workflows/upsert_client_credentials_workflow.go
+++ b/app/domain/workflows/upsert_client_credentials_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertClientCredentialsWorkflow) Map(ctx context.Context) domain.FSMStat
 	}
 }
 
-func (w UpsertClientCredentialsWorkflow) TransitionToClientCredentialsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.ClientCredentialsUpserted())
-}
-
 func (w UpsertClientCredentialsWorkflow) CanTransitionToClientCredentialsUpserted() bool {
 	return w.fsm.Can(w.ClientCredentialsUpserted())
 }

--- a/app/domain/workflows/upsert_contact_workflow.go
+++ b/app/domain/workflows/upsert_contact_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertContactWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertContactWorkflow) TransitionToContactUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.ContactUpserted())
-}
-
 func (w UpsertContactWorkflow) CanTransitionToContactUpserted() bool {
 	return w.fsm.Can(w.ContactUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_history_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_history_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDeliveryUnitsHistoryWorkflow) Map(ctx context.Context) domain.FSMS
 	}
 }
 
-func (w UpsertDeliveryUnitsHistoryWorkflow) TransitionToDeliveryUnitsHistoryUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DeliveryUnitsHistoryUpserted())
-}
-
 func (w UpsertDeliveryUnitsHistoryWorkflow) CanTransitionToDeliveryUnitsHistoryUpserted() bool {
 	return w.fsm.Can(w.DeliveryUnitsHistoryUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_labels_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_labels_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDeliveryUnitsLabelsWorkflow) Map(ctx context.Context) domain.FSMSt
 	}
 }
 
-func (w UpsertDeliveryUnitsLabelsWorkflow) TransitionToDeliveryUnitsLabelsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DeliveryUnitsLabelsUpserted())
-}
-
 func (w UpsertDeliveryUnitsLabelsWorkflow) CanTransitionToDeliveryUnitsLabelsUpserted() bool {
 	return w.fsm.Can(w.DeliveryUnitsLabelsUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_skills_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_skills_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDeliveryUnitsSkillsWorkflow) Map(ctx context.Context) domain.FSMSt
 	}
 }
 
-func (w UpsertDeliveryUnitsSkillsWorkflow) TransitionToDeliveryUnitsSkillsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DeliveryUnitsSkillsUpserted())
-}
-
 func (w UpsertDeliveryUnitsSkillsWorkflow) CanTransitionToDeliveryUnitsSkillsUpserted() bool {
 	return w.fsm.Can(w.DeliveryUnitsSkillsUpserted())
 }

--- a/app/domain/workflows/upsert_delivery_units_workflow.go
+++ b/app/domain/workflows/upsert_delivery_units_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDeliveryUnitsWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertDeliveryUnitsWorkflow) TransitionToDeliveryUnitsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DeliveryUnitsUpserted())
-}
-
 func (w UpsertDeliveryUnitsWorkflow) CanTransitionToDeliveryUnitsUpserted() bool {
 	return w.fsm.Can(w.DeliveryUnitsUpserted())
 }

--- a/app/domain/workflows/upsert_driver_workflow.go
+++ b/app/domain/workflows/upsert_driver_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertDriverWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertDriverWorkflow) TransitionToDriverUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.DriverUpserted())
-}
-
 func (w UpsertDriverWorkflow) CanTransitionToDriverUpserted() bool {
 	return w.fsm.Can(w.DriverUpserted())
 }

--- a/app/domain/workflows/upsert_node_info_headers_workflow.go
+++ b/app/domain/workflows/upsert_node_info_headers_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNodeInfoHeadersWorkflow) Map(ctx context.Context) domain.FSMState 
 	}
 }
 
-func (w UpsertNodeInfoHeadersWorkflow) TransitionToNodeInfoHeadersUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NodeInfoHeadersUpserted())
-}
-
 func (w UpsertNodeInfoHeadersWorkflow) CanTransitionToNodeInfoHeadersUpserted() bool {
 	return w.fsm.Can(w.NodeInfoHeadersUpserted())
 }

--- a/app/domain/workflows/upsert_node_info_workflow.go
+++ b/app/domain/workflows/upsert_node_info_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNodeInfoWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertNodeInfoWorkflow) TransitionToNodeInfoUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NodeInfoUpserted())
-}
-
 func (w UpsertNodeInfoWorkflow) CanTransitionToNodeInfoUpserted() bool {
 	return w.fsm.Can(w.NodeInfoUpserted())
 }

--- a/app/domain/workflows/upsert_node_references_workflow.go
+++ b/app/domain/workflows/upsert_node_references_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNodeReferencesWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertNodeReferencesWorkflow) TransitionToNodeReferencesUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NodeReferencesUpserted())
-}
-
 func (w UpsertNodeReferencesWorkflow) CanTransitionToNodeReferencesUpserted() bool {
 	return w.fsm.Can(w.NodeReferencesUpserted())
 }

--- a/app/domain/workflows/upsert_node_type_workflow.go
+++ b/app/domain/workflows/upsert_node_type_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNodeTypeWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertNodeTypeWorkflow) TransitionToNodeTypeUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NodeTypeUpserted())
-}
-
 func (w UpsertNodeTypeWorkflow) CanTransitionToNodeTypeUpserted() bool {
 	return w.fsm.Can(w.NodeTypeUpserted())
 }

--- a/app/domain/workflows/upsert_non_delivery_reason_workflow.go
+++ b/app/domain/workflows/upsert_non_delivery_reason_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertNonDeliveryReasonWorkflow) Map(ctx context.Context) domain.FSMStat
 	}
 }
 
-func (w UpsertNonDeliveryReasonWorkflow) TransitionToNonDeliveryReasonUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.NonDeliveryReasonUpserted())
-}
-
 func (w UpsertNonDeliveryReasonWorkflow) CanTransitionToNonDeliveryReasonUpserted() bool {
 	return w.fsm.Can(w.NonDeliveryReasonUpserted())
 }

--- a/app/domain/workflows/upsert_order_delivery_units_workflow.go
+++ b/app/domain/workflows/upsert_order_delivery_units_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderDeliveryUnitsWorkflow) Map(ctx context.Context) domain.FSMSta
 	}
 }
 
-func (w UpsertOrderDeliveryUnitsWorkflow) TransitionToOrderDeliveryUnitsUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderDeliveryUnitsUpserted())
-}
-
 func (w UpsertOrderDeliveryUnitsWorkflow) CanTransitionToOrderDeliveryUnitsUpserted() bool {
 	return w.fsm.Can(w.OrderDeliveryUnitsUpserted())
 }

--- a/app/domain/workflows/upsert_order_headers_workflow.go
+++ b/app/domain/workflows/upsert_order_headers_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertOrderHeadersWorkflow) TransitionToOrderHeadersUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderHeadersUpserted())
-}
-
 func (w UpsertOrderHeadersWorkflow) CanTransitionToOrderHeadersUpserted() bool {
 	return w.fsm.Can(w.OrderHeadersUpserted())
 }

--- a/app/domain/workflows/upsert_order_references_workflow.go
+++ b/app/domain/workflows/upsert_order_references_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderReferencesWorkflow) Map(ctx context.Context) domain.FSMState 
 	}
 }
 
-func (w UpsertOrderReferencesWorkflow) TransitionToOrderReferencesUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderReferencesUpserted())
-}
-
 func (w UpsertOrderReferencesWorkflow) CanTransitionToOrderReferencesUpserted() bool {
 	return w.fsm.Can(w.OrderReferencesUpserted())
 }

--- a/app/domain/workflows/upsert_order_type_workflow.go
+++ b/app/domain/workflows/upsert_order_type_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderTypeWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertOrderTypeWorkflow) TransitionToOrderTypeUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderTypeUpserted())
-}
-
 func (w UpsertOrderTypeWorkflow) CanTransitionToOrderTypeUpserted() bool {
 	return w.fsm.Can(w.OrderTypeUpserted())
 }

--- a/app/domain/workflows/upsert_order_workflow.go
+++ b/app/domain/workflows/upsert_order_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertOrderWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertOrderWorkflow) TransitionToOrderUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.OrderUpserted())
-}
-
 func (w UpsertOrderWorkflow) CanTransitionToOrderUpserted() bool {
 	return w.fsm.Can(w.OrderUpserted())
 }

--- a/app/domain/workflows/upsert_plan_headers_workflow.go
+++ b/app/domain/workflows/upsert_plan_headers_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertPlanHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertPlanHeadersWorkflow) TransitionToPlanHeadersUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.PlanHeadersUpserted())
-}
-
 func (w UpsertPlanHeadersWorkflow) CanTransitionToPlanHeadersUpserted() bool {
 	return w.fsm.Can(w.PlanHeadersUpserted())
 }

--- a/app/domain/workflows/upsert_plan_workflow.go
+++ b/app/domain/workflows/upsert_plan_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertPlanWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertPlanWorkflow) TransitionToPlanUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.PlanUpserted())
-}
-
 func (w UpsertPlanWorkflow) CanTransitionToPlanUpserted() bool {
 	return w.fsm.Can(w.PlanUpserted())
 }

--- a/app/domain/workflows/upsert_political_area_workflow.go
+++ b/app/domain/workflows/upsert_political_area_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertPoliticalAreaWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertPoliticalAreaWorkflow) TransitionToPoliticalAreaUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.PoliticalAreaUpserted())
-}
-
 func (w UpsertPoliticalAreaWorkflow) CanTransitionToPoliticalAreaUpserted() bool {
 	return w.fsm.Can(w.PoliticalAreaUpserted())
 }

--- a/app/domain/workflows/upsert_route_workflow.go
+++ b/app/domain/workflows/upsert_route_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertRouteWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertRouteWorkflow) TransitionToRouteUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.RouteUpserted())
-}
-
 func (w UpsertRouteWorkflow) CanTransitionToRouteUpserted() bool {
 	return w.fsm.Can(w.RouteUpserted())
 }

--- a/app/domain/workflows/upsert_size_category_workflow.go
+++ b/app/domain/workflows/upsert_size_category_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertSizeCategoryWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertSizeCategoryWorkflow) TransitionToSizeCategoryUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.SizeCategoryUpserted())
-}
-
 func (w UpsertSizeCategoryWorkflow) CanTransitionToSizeCategoryUpserted() bool {
 	return w.fsm.Can(w.SizeCategoryUpserted())
 }

--- a/app/domain/workflows/upsert_skill_workflow.go
+++ b/app/domain/workflows/upsert_skill_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertSkillWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertSkillWorkflow) TransitionToSkillUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.SkillUpserted())
-}
-
 func (w UpsertSkillWorkflow) CanTransitionToSkillUpserted() bool {
 	return w.fsm.Can(w.SkillUpserted())
 }

--- a/app/domain/workflows/upsert_vehicle_category_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_category_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertVehicleCategoryWorkflow) Map(ctx context.Context) domain.FSMState 
 	}
 }
 
-func (w UpsertVehicleCategoryWorkflow) TransitionToVehicleCategoryUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.VehicleCategoryUpserted())
-}
-
 func (w UpsertVehicleCategoryWorkflow) CanTransitionToVehicleCategoryUpserted() bool {
 	return w.fsm.Can(w.VehicleCategoryUpserted())
 }

--- a/app/domain/workflows/upsert_vehicle_headers_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_headers_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertVehicleHeadersWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertVehicleHeadersWorkflow) TransitionToVehicleHeadersUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.VehicleHeadersUpserted())
-}
-
 func (w UpsertVehicleHeadersWorkflow) CanTransitionToVehicleHeadersUpserted() bool {
 	return w.fsm.Can(w.VehicleHeadersUpserted())
 }

--- a/app/domain/workflows/upsert_vehicle_workflow.go
+++ b/app/domain/workflows/upsert_vehicle_workflow.go
@@ -69,10 +69,6 @@ func (w UpsertVehicleWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w UpsertVehicleWorkflow) TransitionToVehicleUpserted(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.VehicleUpserted())
-}
-
 func (w UpsertVehicleWorkflow) CanTransitionToVehicleUpserted() bool {
 	return w.fsm.Can(w.VehicleUpserted())
 }


### PR DESCRIPTION
Remove unused duplicate `TransitionTo<Workflow>Upserted` methods from workflow files to reduce API surface.

All 28 workflow files contained two methods, `TransitionTo<Workflow>Upserted()` and `Set<Workflow>UpsertedTransition()`, which performed identical operations. Analysis showed that `TransitionTo<Workflow>Upserted()` was unused, while `Set<Workflow>UpsertedTransition()` was actively used. This PR removes the unused `TransitionTo<Workflow>Upserted()` methods to eliminate redundant API surface and reduce maintenance overhead.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d614db30-d737-43de-8fd6-3a7c820fafeb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d614db30-d737-43de-8fd6-3a7c820fafeb)