### PR TITLE
Remove duplicate tenant save workflow methods

### DIFF
--- a/app/domain/workflows/save_tenant_workflow.go
+++ b/app/domain/workflows/save_tenant_workflow.go
@@ -69,10 +69,6 @@ func (w SaveTenantWorkflow) Map(ctx context.Context) domain.FSMState {
 	}
 }
 
-func (w SaveTenantWorkflow) TransitionToTenantSaved(ctx context.Context) error {
-	return w.fsm.Event(ctx, w.TenantSaved())
-}
-
 func (w SaveTenantWorkflow) CanTransitionToTenantSaved() bool {
 	return w.fsm.Can(w.TenantSaved())
 }


### PR DESCRIPTION
Remove duplicate `TransitionToTenantSaved` method to align with workflow standardization.

---

[Open in Web](https://www.cursor.com/agents?id=bc-01938a2d-b34b-43de-830c-3dc58fe9c242) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-01938a2d-b34b-43de-830c-3dc58fe9c242)