### PR TITLE
Crear casos de uso para repositorios con FSM

### DIFF
--- a/app/usecase/upsert_carrier_workflow.go
+++ b/app/usecase/upsert_carrier_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertCarrierWorkflow func(ctx context.Context, c domain.Carrier) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertCarrierWorkflow,
+		workflows.NewUpsertCarrierWorkflow,
+		tidbrepository.NewUpsertCarrier,
+		observability.NewObservability)
+}
+
+func NewUpsertCarrierWorkflow(
+	domainWorkflow workflows.UpsertCarrierWorkflow,
+	upsertCarrier tidbrepository.UpsertCarrier,
+	obs observability.Observability,
+) UpsertCarrierWorkflow {
+	return func(ctx context.Context, c domain.Carrier) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "carrier", c)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetCarrierUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"carrier_doc_id", c.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertCarrier(ctx, c, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert carrier: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_delivery_units_skills_workflow.go
+++ b/app/usecase/upsert_delivery_units_skills_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertDeliveryUnitsSkillsWorkflow func(ctx context.Context, order domain.Order) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertDeliveryUnitsSkillsWorkflow,
+		workflows.NewUpsertDeliveryUnitsSkillsWorkflow,
+		tidbrepository.NewUpsertDeliveryUnitsSkills,
+		observability.NewObservability)
+}
+
+func NewUpsertDeliveryUnitsSkillsWorkflow(
+	domainWorkflow workflows.UpsertDeliveryUnitsSkillsWorkflow,
+	upsertDeliveryUnitsSkills tidbrepository.UpsertDeliveryUnitsSkills,
+	obs observability.Observability,
+) UpsertDeliveryUnitsSkillsWorkflow {
+	return func(ctx context.Context, order domain.Order) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "delivery_units_skills", order)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetDeliveryUnitsSkillsUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"delivery_units_skills_doc_id", order.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertDeliveryUnitsSkills(ctx, order, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert delivery units skills: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_node_info_headers_workflow.go
+++ b/app/usecase/upsert_node_info_headers_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertNodeInfoHeadersWorkflow func(ctx context.Context, nih domain.Headers) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertNodeInfoHeadersWorkflow,
+		workflows.NewUpsertNodeInfoHeadersWorkflow,
+		tidbrepository.NewUpsertNodeInfoHeaders,
+		observability.NewObservability)
+}
+
+func NewUpsertNodeInfoHeadersWorkflow(
+	domainWorkflow workflows.UpsertNodeInfoHeadersWorkflow,
+	upsertNodeInfoHeaders tidbrepository.UpsertNodeInfoHeaders,
+	obs observability.Observability,
+) UpsertNodeInfoHeadersWorkflow {
+	return func(ctx context.Context, nih domain.Headers) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "node_info_headers", nih)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetNodeInfoHeadersUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"node_info_headers_doc_id", nih.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertNodeInfoHeaders(ctx, nih, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert node info headers: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_node_info_workflow.go
+++ b/app/usecase/upsert_node_info_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertNodeInfoWorkflow func(ctx context.Context, ni domain.NodeInfo) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertNodeInfoWorkflow,
+		workflows.NewUpsertNodeInfoWorkflow,
+		tidbrepository.NewUpsertNodeInfo,
+		observability.NewObservability)
+}
+
+func NewUpsertNodeInfoWorkflow(
+	domainWorkflow workflows.UpsertNodeInfoWorkflow,
+	upsertNodeInfo tidbrepository.UpsertNodeInfo,
+	obs observability.Observability,
+) UpsertNodeInfoWorkflow {
+	return func(ctx context.Context, ni domain.NodeInfo) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "node_info", ni)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetNodeInfoUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"node_info_doc_id", ni.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertNodeInfo(ctx, ni, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert node info: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_order_delivery_units_workflow.go
+++ b/app/usecase/upsert_order_delivery_units_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertOrderDeliveryUnitsWorkflow func(ctx context.Context, order domain.Order) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertOrderDeliveryUnitsWorkflow,
+		workflows.NewUpsertOrderDeliveryUnitsWorkflow,
+		tidbrepository.NewUpsertOrderDeliveryUnits,
+		observability.NewObservability)
+}
+
+func NewUpsertOrderDeliveryUnitsWorkflow(
+	domainWorkflow workflows.UpsertOrderDeliveryUnitsWorkflow,
+	upsertOrderDeliveryUnits tidbrepository.UpsertOrderDeliveryUnits,
+	obs observability.Observability,
+) UpsertOrderDeliveryUnitsWorkflow {
+	return func(ctx context.Context, order domain.Order) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "order_delivery_units", order)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetOrderDeliveryUnitsUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"order_delivery_units_doc_id", order.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertOrderDeliveryUnits(ctx, order, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert order delivery units: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_order_type_workflow.go
+++ b/app/usecase/upsert_order_type_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertOrderTypeWorkflow func(ctx context.Context, ot domain.OrderType) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertOrderTypeWorkflow,
+		workflows.NewUpsertOrderTypeWorkflow,
+		tidbrepository.NewUpsertOrderType,
+		observability.NewObservability)
+}
+
+func NewUpsertOrderTypeWorkflow(
+	domainWorkflow workflows.UpsertOrderTypeWorkflow,
+	upsertOrderType tidbrepository.UpsertOrderType,
+	obs observability.Observability,
+) UpsertOrderTypeWorkflow {
+	return func(ctx context.Context, ot domain.OrderType) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "order_type", ot)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetOrderTypeUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"order_type_doc_id", ot.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertOrderType(ctx, ot, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert order type: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_order_workflow.go
+++ b/app/usecase/upsert_order_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertOrderWorkflow func(ctx context.Context, o domain.Order) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertOrderWorkflow,
+		workflows.NewUpsertOrderWorkflow,
+		tidbrepository.NewUpsertOrder,
+		observability.NewObservability)
+}
+
+func NewUpsertOrderWorkflow(
+	domainWorkflow workflows.UpsertOrderWorkflow,
+	upsertOrder tidbrepository.UpsertOrder,
+	obs observability.Observability,
+) UpsertOrderWorkflow {
+	return func(ctx context.Context, o domain.Order) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "order", o)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetOrderUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"order_doc_id", o.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertOrder(ctx, o, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert order: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_plan_headers_workflow.go
+++ b/app/usecase/upsert_plan_headers_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertPlanHeadersWorkflow func(ctx context.Context, headers domain.Headers) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertPlanHeadersWorkflow,
+		workflows.NewUpsertPlanHeadersWorkflow,
+		tidbrepository.NewUpsertPlanHeaders,
+		observability.NewObservability)
+}
+
+func NewUpsertPlanHeadersWorkflow(
+	domainWorkflow workflows.UpsertPlanHeadersWorkflow,
+	upsertPlanHeaders tidbrepository.UpsertPlanHeaders,
+	obs observability.Observability,
+) UpsertPlanHeadersWorkflow {
+	return func(ctx context.Context, headers domain.Headers) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "plan_headers", headers)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetPlanHeadersUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"plan_headers_doc_id", headers.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertPlanHeaders(ctx, headers, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert plan headers: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_political_area_workflow.go
+++ b/app/usecase/upsert_political_area_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertPoliticalAreaWorkflow func(ctx context.Context, pa domain.PoliticalArea) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertPoliticalAreaWorkflow,
+		workflows.NewUpsertPoliticalAreaWorkflow,
+		tidbrepository.NewUpsertPoliticalArea,
+		observability.NewObservability)
+}
+
+func NewUpsertPoliticalAreaWorkflow(
+	domainWorkflow workflows.UpsertPoliticalAreaWorkflow,
+	upsertPoliticalArea tidbrepository.UpsertPoliticalArea,
+	obs observability.Observability,
+) UpsertPoliticalAreaWorkflow {
+	return func(ctx context.Context, pa domain.PoliticalArea) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "political_area", pa)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetPoliticalAreaUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"political_area_doc_id", pa.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertPoliticalArea(ctx, pa, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert political area: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_size_category_workflow.go
+++ b/app/usecase/upsert_size_category_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertSizeCategoryWorkflow func(ctx context.Context, sc domain.SizeCategory) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertSizeCategoryWorkflow,
+		workflows.NewUpsertSizeCategoryWorkflow,
+		tidbrepository.NewUpsertSizeCategory,
+		observability.NewObservability)
+}
+
+func NewUpsertSizeCategoryWorkflow(
+	domainWorkflow workflows.UpsertSizeCategoryWorkflow,
+	upsertSizeCategory tidbrepository.UpsertSizeCategory,
+	obs observability.Observability,
+) UpsertSizeCategoryWorkflow {
+	return func(ctx context.Context, sc domain.SizeCategory) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "size_category", sc)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetSizeCategoryUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"size_category_doc_id", sc.DocumentID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertSizeCategory(ctx, sc, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert size category: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_vehicle_category_workflow.go
+++ b/app/usecase/upsert_vehicle_category_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertVehicleCategoryWorkflow func(ctx context.Context, vc domain.VehicleCategory) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertVehicleCategoryWorkflow,
+		workflows.NewUpsertVehicleCategoryWorkflow,
+		tidbrepository.NewUpsertVehicleCategory,
+		observability.NewObservability)
+}
+
+func NewUpsertVehicleCategoryWorkflow(
+	domainWorkflow workflows.UpsertVehicleCategoryWorkflow,
+	upsertVehicleCategory tidbrepository.UpsertVehicleCategory,
+	obs observability.Observability,
+) UpsertVehicleCategoryWorkflow {
+	return func(ctx context.Context, vc domain.VehicleCategory) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "vehicle_category", vc)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetVehicleCategoryUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"vehicle_category_doc_id", vc.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertVehicleCategory(ctx, vc, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert vehicle category: %w", err)
+		}
+		return nil
+	}
+}

--- a/app/usecase/upsert_vehicle_workflow.go
+++ b/app/usecase/upsert_vehicle_workflow.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"transport-app/app/adapter/out/tidbrepository"
+	"transport-app/app/domain"
+	"transport-app/app/domain/workflows"
+	canonicaljson "transport-app/app/shared/caonincaljson"
+	"transport-app/app/shared/infrastructure/observability"
+
+	ioc "github.com/Ignaciojeria/einar-ioc/v2"
+)
+
+type UpsertVehicleWorkflow func(ctx context.Context, v domain.Vehicle) error
+
+func init() {
+	ioc.Registry(
+		NewUpsertVehicleWorkflow,
+		workflows.NewUpsertVehicleWorkflow,
+		tidbrepository.NewUpsertVehicle,
+		observability.NewObservability)
+}
+
+func NewUpsertVehicleWorkflow(
+	domainWorkflow workflows.UpsertVehicleWorkflow,
+	upsertVehicle tidbrepository.UpsertVehicle,
+	obs observability.Observability,
+) UpsertVehicleWorkflow {
+	return func(ctx context.Context, v domain.Vehicle) error {
+		// Usar el documentID como idempotency key para el workflow
+		key, err := canonicaljson.HashKey(ctx, "vehicle", v)
+		if err != nil {
+			return fmt.Errorf("failed to hash key: %w", err)
+		}
+		workflow, err := domainWorkflow.Restore(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to restore workflow: %w", err)
+		}
+		if err := workflow.SetVehicleUpsertedTransition(ctx); err != nil {
+			obs.Logger.WarnContext(ctx,
+				err.Error(),
+				"vehicle_doc_id", v.DocID(ctx).String())
+			return nil
+		}
+		fsmState := workflow.Map(ctx)
+		err = upsertVehicle(ctx, v, fsmState)
+		if err != nil {
+			return fmt.Errorf("failed to upsert vehicle: %w", err)
+		}
+		return nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.30.0
 	gorm.io/plugin/opentelemetry v0.1.16
+	olympos.io/encoding/cjson v0.0.0-20191103175252-b41f647ea928
 )
 
 require (
@@ -212,7 +213,6 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/clickhouse v0.7.0 // indirect
-	olympos.io/encoding/cjson v0.0.0-20191103175252-b41f647ea928 // indirect
 )
 
 replace github.com/ugorji/go => github.com/ugorji/go v1.2.12


### PR DESCRIPTION
Add 12 new use cases to orchestrate FSM-driven repository operations with their corresponding workflows.

---

[Open in Web](https://www.cursor.com/agents?id=bc-3f7f9397-c43e-4ab9-93d1-0f85835b616d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3f7f9397-c43e-4ab9-93d1-0f85835b616d)