### PR TITLE
Set idempotency key in context for workflows

### DIFF
--- a/app/adapter/in/natsconsumer/order_submitted.go
+++ b/app/adapter/in/natsconsumer/order_submitted.go
@@ -123,77 +123,199 @@ func newNatsConsumer(
 			msg.Nak()
 			return
 		}
-		if err := upsertContactWorkflow(ctx, order.Origin.AddressInfo.Contact); err != nil {
+
+		// Contactos
+		originContactKey, err := canonicaljson.HashKey(ctx, "contact", order.Origin.AddressInfo.Contact)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para contacto origen", "error", err)
+			msg.Nak()
+			return
+		}
+		originContactCtx := sharedcontext.WithIdempotencyKey(ctx, originContactKey)
+		if err := upsertContactWorkflow(originContactCtx, order.Origin.AddressInfo.Contact); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando contacto origen", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertContactWorkflow(ctx, order.Destination.AddressInfo.Contact); err != nil {
+
+		destContactKey, err := canonicaljson.HashKey(ctx, "contact", order.Destination.AddressInfo.Contact)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para contacto destino", "error", err)
+			msg.Nak()
+			return
+		}
+		destContactCtx := sharedcontext.WithIdempotencyKey(ctx, destContactKey)
+		if err := upsertContactWorkflow(destContactCtx, order.Destination.AddressInfo.Contact); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando contacto destino", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertAddressInfoWorkflow(ctx, order.Origin.AddressInfo); err != nil {
+
+		// Address Info
+		originAddressKey, err := canonicaljson.HashKey(ctx, "address_info", order.Origin.AddressInfo)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para dirección origen", "error", err)
+			msg.Nak()
+			return
+		}
+		originAddressCtx := sharedcontext.WithIdempotencyKey(ctx, originAddressKey)
+		if err := upsertAddressInfoWorkflow(originAddressCtx, order.Origin.AddressInfo); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando dirección origen", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertAddressInfoWorkflow(ctx, order.Destination.AddressInfo); err != nil {
+
+		destAddressKey, err := canonicaljson.HashKey(ctx, "address_info", order.Destination.AddressInfo)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para dirección destino", "error", err)
+			msg.Nak()
+			return
+		}
+		destAddressCtx := sharedcontext.WithIdempotencyKey(ctx, destAddressKey)
+		if err := upsertAddressInfoWorkflow(destAddressCtx, order.Destination.AddressInfo); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando dirección destino", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertOrderTypeWorkflow(ctx, order.OrderType); err != nil {
+
+		// Order Type
+		orderTypeKey, err := canonicaljson.HashKey(ctx, "order_type", order.OrderType)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para tipo de orden", "error", err)
+			msg.Nak()
+			return
+		}
+		orderTypeCtx := sharedcontext.WithIdempotencyKey(ctx, orderTypeKey)
+		if err := upsertOrderTypeWorkflow(orderTypeCtx, order.OrderType); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando tipo de orden", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertDeliveryUnitsWorkflow(ctx, order.DeliveryUnits); err != nil {
+
+		// Delivery Units
+		deliveryUnitsKey, err := canonicaljson.HashKey(ctx, "delivery_units", order.DeliveryUnits)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para unidades de entrega", "error", err)
+			msg.Nak()
+			return
+		}
+		deliveryUnitsCtx := sharedcontext.WithIdempotencyKey(ctx, deliveryUnitsKey)
+		if err := upsertDeliveryUnitsWorkflow(deliveryUnitsCtx, order.DeliveryUnits); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando unidades de entrega", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertOrderReferencesWorkflow(ctx, order); err != nil {
+
+		// Order References
+		orderReferencesKey, err := canonicaljson.HashKey(ctx, "order_references", order)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para referencias de orden", "error", err)
+			msg.Nak()
+			return
+		}
+		orderReferencesCtx := sharedcontext.WithIdempotencyKey(ctx, orderReferencesKey)
+		if err := upsertOrderReferencesWorkflow(orderReferencesCtx, order); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando referencias de orden", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertOrderDeliveryUnitsWorkflow(ctx, order); err != nil {
+
+		// Order Delivery Units
+		orderDeliveryUnitsKey, err := canonicaljson.HashKey(ctx, "order_delivery_units", order)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para relación orden-unidades", "error", err)
+			msg.Nak()
+			return
+		}
+		orderDeliveryUnitsCtx := sharedcontext.WithIdempotencyKey(ctx, orderDeliveryUnitsKey)
+		if err := upsertOrderDeliveryUnitsWorkflow(orderDeliveryUnitsCtx, order); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando relación orden-unidades", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertOrderWorkflow(ctx, order); err != nil {
+
+		// Order
+		orderKey, err := canonicaljson.HashKey(ctx, "order", order)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para orden", "error", err)
+			msg.Nak()
+			return
+		}
+		orderCtx := sharedcontext.WithIdempotencyKey(ctx, orderKey)
+		if err := upsertOrderWorkflow(orderCtx, order); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando upsert de orden", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertDeliveryUnitsLabelsWorkflow(ctx, order); err != nil {
+
+		// Delivery Units Labels
+		deliveryUnitsLabelsKey, err := canonicaljson.HashKey(ctx, "delivery_units_labels", order)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para labels de unidades de entrega", "error", err)
+			msg.Nak()
+			return
+		}
+		deliveryUnitsLabelsCtx := sharedcontext.WithIdempotencyKey(ctx, deliveryUnitsLabelsKey)
+		if err := upsertDeliveryUnitsLabelsWorkflow(deliveryUnitsLabelsCtx, order); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando labels de unidades de entrega", "error", err)
 			msg.Nak()
 			return
 		}
-		if err := upsertDeliveryUnitsSkillsWorkflow(ctx, order); err != nil {
+
+		// Delivery Units Skills
+		deliveryUnitsSkillsKey, err := canonicaljson.HashKey(ctx, "delivery_units_skills", order)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para skills de unidades de entrega", "error", err)
+			msg.Nak()
+			return
+		}
+		deliveryUnitsSkillsCtx := sharedcontext.WithIdempotencyKey(ctx, deliveryUnitsSkillsKey)
+		if err := upsertDeliveryUnitsSkillsWorkflow(deliveryUnitsSkillsCtx, order); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando skills de unidades de entrega", "error", err)
 			msg.Nak()
 			return
 		}
+
+		// Size Categories y Skills
 		for _, du := range order.DeliveryUnits {
-			if err := upsertSizeCategoryWorkflow(ctx, du.SizeCategory); err != nil {
+			sizeCategoryKey, err := canonicaljson.HashKey(ctx, "size_category", du.SizeCategory)
+			if err != nil {
+				obs.Logger.ErrorContext(ctx, "Error generando key para size category", "error", err)
+				msg.Nak()
+				return
+			}
+			sizeCategoryCtx := sharedcontext.WithIdempotencyKey(ctx, sizeCategoryKey)
+			if err := upsertSizeCategoryWorkflow(sizeCategoryCtx, du.SizeCategory); err != nil {
 				obs.Logger.ErrorContext(ctx, "Error procesando size category", "error", err)
 				msg.Nak()
 				return
 			}
 			for _, skill := range du.Skills {
-				if err := upsertSkillWorkflow(ctx, skill); err != nil {
+				skillKey, err := canonicaljson.HashKey(ctx, "skill", skill)
+				if err != nil {
+					obs.Logger.ErrorContext(ctx, "Error generando key para skill", "error", err)
+					msg.Nak()
+					return
+				}
+				skillCtx := sharedcontext.WithIdempotencyKey(ctx, skillKey)
+				if err := upsertSkillWorkflow(skillCtx, skill); err != nil {
 					obs.Logger.ErrorContext(ctx, "Error procesando skill", "error", err)
 					msg.Nak()
 					return
 				}
 			}
 		}
+
+		// Delivery Units History
 		plan := domain.Plan{Routes: []domain.Route{{Orders: []domain.Order{order}}}}
-		if err := upsertDeliveryUnitsHistoryWorkflow(ctx, plan); err != nil {
+		deliveryUnitsHistoryKey, err := canonicaljson.HashKey(ctx, "delivery_units_history", plan)
+		if err != nil {
+			obs.Logger.ErrorContext(ctx, "Error generando key para historial de unidades de entrega", "error", err)
+			msg.Nak()
+			return
+		}
+		deliveryUnitsHistoryCtx := sharedcontext.WithIdempotencyKey(ctx, deliveryUnitsHistoryKey)
+		if err := upsertDeliveryUnitsHistoryWorkflow(deliveryUnitsHistoryCtx, plan); err != nil {
 			obs.Logger.ErrorContext(ctx, "Error procesando historial de unidades de entrega", "error", err)
 			msg.Nak()
 			return

--- a/app/adapter/out/tidbrepository/upsert_order_delivery_units.go
+++ b/app/adapter/out/tidbrepository/upsert_order_delivery_units.go
@@ -23,10 +23,7 @@ func NewUpsertOrderDeliveryUnits(conn database.ConnectionFactory, saveFSMTransit
 	return func(ctx context.Context, order domain.Order, fsmState ...domain.FSMState) error {
 		orderPackages := mapper.MapOrderDeliveryUnits(ctx, order)
 		return conn.Transaction(func(tx *gorm.DB) error {
-			if err := tx.Where("order_doc = ?", order.DocID(ctx)).
-				Delete(&table.OrderDeliveryUnit{}).Error; err != nil {
-				return err
-			}
+
 			if len(orderPackages) > 0 {
 				if err := tx.Save(&orderPackages).Error; err != nil {
 					return err

--- a/app/usecase/create_account_workflow.go
+++ b/app/usecase/create_account_workflow.go
@@ -7,6 +7,7 @@ import (
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -27,7 +28,12 @@ func NewCreateAccountWorkflow(
 	upsertAccount tidbrepository.UpsertAccount,
 	obs observability.Observability) CreateAccountWorkflow {
 	return func(ctx context.Context, input domain.Account) error {
-		workflow, err := createAccountWorkflow.Restore(ctx, input.Email)
+		// Obtener el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
+		}
+		workflow, err := createAccountWorkflow.Restore(ctx, key)
 		if err != nil {
 			return fmt.Errorf("failed to restore workflow: %w", err)
 		}

--- a/app/usecase/upsert_address_info_workflow.go
+++ b/app/usecase/upsert_address_info_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,10 +28,10 @@ func NewUpsertAddressInfoWorkflow(
 	obs observability.Observability,
 ) UpsertAddressInfoWorkflow {
 	return func(ctx context.Context, ai domain.AddressInfo) error {
-		// Usar el documentID como idempotency key para el workflow
-		key, err := canonicaljson.HashKey(ctx, "address_info", ai)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_delivery_units_history_workflow.go
+++ b/app/usecase/upsert_delivery_units_history_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,9 +28,10 @@ func NewUpsertDeliveryUnitsHistoryWorkflow(
 	obs observability.Observability,
 ) UpsertDeliveryUnitsHistoryWorkflow {
 	return func(ctx context.Context, plan domain.Plan) error {
-		key, err := canonicaljson.HashKey(ctx, "delivery_units_history", plan)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_delivery_units_labels_workflow.go
+++ b/app/usecase/upsert_delivery_units_labels_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,9 +28,10 @@ func NewUpsertDeliveryUnitsLabelsWorkflow(
 	obs observability.Observability,
 ) UpsertDeliveryUnitsLabelsWorkflow {
 	return func(ctx context.Context, order domain.Order) error {
-		key, err := canonicaljson.HashKey(ctx, "delivery_units_labels", order)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_delivery_units_skills_workflow.go
+++ b/app/usecase/upsert_delivery_units_skills_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,10 +28,10 @@ func NewUpsertDeliveryUnitsSkillsWorkflow(
 	obs observability.Observability,
 ) UpsertDeliveryUnitsSkillsWorkflow {
 	return func(ctx context.Context, order domain.Order) error {
-		// Usar el documentID como idempotency key para el workflow
-		key, err := canonicaljson.HashKey(ctx, "delivery_units_skills", order)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_delivery_units_workflow.go
+++ b/app/usecase/upsert_delivery_units_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,10 +28,10 @@ func NewUpsertDeliveryUnitsWorkflow(
 	obs observability.Observability,
 ) UpsertDeliveryUnitsWorkflow {
 	return func(ctx context.Context, deliveryUnits []domain.DeliveryUnit) error {
-		// Usar el hash de los delivery units como idempotency key
-		key, err := canonicaljson.HashKey(ctx, "delivery_units", deliveryUnits)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_order_delivery_units_workflow.go
+++ b/app/usecase/upsert_order_delivery_units_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,10 +28,10 @@ func NewUpsertOrderDeliveryUnitsWorkflow(
 	obs observability.Observability,
 ) UpsertOrderDeliveryUnitsWorkflow {
 	return func(ctx context.Context, order domain.Order) error {
-		// Usar el documentID como idempotency key para el workflow
-		key, err := canonicaljson.HashKey(ctx, "order_delivery_units", order)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_order_references_workflow.go
+++ b/app/usecase/upsert_order_references_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,9 +28,10 @@ func NewUpsertOrderReferencesWorkflow(
 	obs observability.Observability,
 ) UpsertOrderReferencesWorkflow {
 	return func(ctx context.Context, order domain.Order) error {
-		key, err := canonicaljson.HashKey(ctx, "order_references", order)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_order_type_workflow.go
+++ b/app/usecase/upsert_order_type_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,10 +28,10 @@ func NewUpsertOrderTypeWorkflow(
 	obs observability.Observability,
 ) UpsertOrderTypeWorkflow {
 	return func(ctx context.Context, ot domain.OrderType) error {
-		// Usar el documentID como idempotency key para el workflow
-		key, err := canonicaljson.HashKey(ctx, "order_type", ot)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_order_workflow.go
+++ b/app/usecase/upsert_order_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,10 +28,10 @@ func NewUpsertOrderWorkflow(
 	obs observability.Observability,
 ) UpsertOrderWorkflow {
 	return func(ctx context.Context, o domain.Order) error {
-		// Usar el documentID como idempotency key para el workflow
-		key, err := canonicaljson.HashKey(ctx, "order", o)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_size_category_workflow.go
+++ b/app/usecase/upsert_size_category_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,10 +28,10 @@ func NewUpsertSizeCategoryWorkflow(
 	obs observability.Observability,
 ) UpsertSizeCategoryWorkflow {
 	return func(ctx context.Context, sc domain.SizeCategory) error {
-		// Usar el documentID como idempotency key para el workflow
-		key, err := canonicaljson.HashKey(ctx, "size_category", sc)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {

--- a/app/usecase/upsert_skill_workflow.go
+++ b/app/usecase/upsert_skill_workflow.go
@@ -6,8 +6,8 @@ import (
 	"transport-app/app/adapter/out/tidbrepository"
 	"transport-app/app/domain"
 	"transport-app/app/domain/workflows"
-	canonicaljson "transport-app/app/shared/caonincaljson"
 	"transport-app/app/shared/infrastructure/observability"
+	"transport-app/app/shared/sharedcontext"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 )
@@ -28,9 +28,10 @@ func NewUpsertSkillWorkflow(
 	obs observability.Observability,
 ) UpsertSkillWorkflow {
 	return func(ctx context.Context, skill domain.Skill) error {
-		key, err := canonicaljson.HashKey(ctx, "skill", skill)
-		if err != nil {
-			return fmt.Errorf("failed to hash key: %w", err)
+		// Usar el idempotency key desde el contexto
+		key, ok := sharedcontext.IdempotencyKeyFromContext(ctx)
+		if !ok {
+			return fmt.Errorf("idempotency key not found in context")
 		}
 		workflow, err := domainWorkflow.Restore(ctx, key)
 		if err != nil {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor all use case workflows to retrieve idempotency keys from the context, centralizing key generation in the NATS consumer.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b9fc87a-15f3-431f-a9a2-40abd95b8f43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b9fc87a-15f3-431f-a9a2-40abd95b8f43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>