### PR TITLE
Get route by id from storj bucket

### DIFF
--- a/app/adapter/in/fuegoapi/upsert_route.go
+++ b/app/adapter/in/fuegoapi/upsert_route.go
@@ -2,17 +2,22 @@ package fuegoapi
 
 import (
 	"fmt"
+	"time"
 	"transport-app/app/adapter/in/fuegoapi/request"
+	"transport-app/app/adapter/out/storjbucket"
 	"transport-app/app/shared/infrastructure/httpserver"
 
 	ioc "github.com/Ignaciojeria/einar-ioc/v2"
 	"github.com/go-fuego/fuego"
 	"github.com/go-fuego/fuego/option"
+	"storj.io/uplink"
 )
 
 func init() {
 	ioc.Registry(upsertRoute, httpserver.New)
+	ioc.Registry(getRoute, httpserver.New, storjbucket.NewTransportAppBucket)
 }
+
 func upsertRoute(s httpserver.Server) {
 	fuego.Post(s.Manager, "/routes",
 		func(c fuego.ContextWithBody[request.UpsertRouteRequest]) (any, error) {
@@ -20,5 +25,37 @@ func upsertRoute(s httpserver.Server) {
 			return "unimplemented", nil
 		},
 		option.Summary("upsert route"),
+		option.Tags(tagRoutes))
+}
+
+func getRoute(s httpserver.Server, storjBucket *storjbucket.TransportAppBucket) {
+	fuego.Get(s.Manager, "/routes/{id}",
+		func(c fuego.ContextNoBody) (any, error) {
+			ctx := c.Context()
+			
+			// Obtener el ID de la ruta desde los parámetros de la URL
+			routeID := c.PathParam("id")
+			if routeID == "" {
+				return nil, fmt.Errorf("route ID is required")
+			}
+
+			// Generar token efímero para acceder al bucket
+			token, err := storjBucket.GenerateEphemeralToken(ctx, time.Hour*1, uplink.Permission{
+				AllowDownload: true,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error generating ephemeral token: %w", err)
+			}
+
+			// Descargar la ruta desde el StorJ bucket usando el ID
+			routeData, err := storjBucket.DownloadWithToken(ctx, token, routeID)
+			if err != nil {
+				return nil, fmt.Errorf("error downloading route from bucket: %w", err)
+			}
+
+			// Retornar los datos de la ruta (como JSON crudo o deserializar según necesidad)
+			return string(routeData), nil
+		},
+		option.Summary("get route by ID"),
 		option.Tags(tagRoutes))
 }


### PR DESCRIPTION
Add GET /routes/{id} endpoint to retrieve a route by ID from StorJ bucket.

---
<a href="https://cursor.com/background-agent?bcId=bc-196681d7-9161-4b04-aa08-09f60c4c66ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-196681d7-9161-4b04-aa08-09f60c4c66ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>