### PR TITLE
Actualizar seguro de unidad de entrega

### DIFF
--- a/app/adapter/in/graphql/graph/deliveryunits.graphqls
+++ b/app/adapter/in/graphql/graph/deliveryunits.graphqls
@@ -104,7 +104,7 @@ type DeliveryUnit {
   sizeCategory: String
   volume: Long
   weight: Long
-  insurance: Long
+  unitPrice: Long
   items: [Item]
   labels: [Label]
   skills: [String]

--- a/app/adapter/in/graphql/graph/mapper/map_delivery_units.go
+++ b/app/adapter/in/graphql/graph/mapper/map_delivery_units.go
@@ -222,7 +222,7 @@ func MapDeliveryUnits(ctx context.Context, deliveryUnits []projectionresult.Deli
 				SizeCategory: &du.SizeCategory,
 				Volume:       &du.Volume,
 				Weight:       &du.Weight,
-				Insurance:    &du.Insurance,
+				UnitPrice:    &du.Insurance,
 				Items: func() []*model.Item {
 					if du.JSONItems == nil {
 						return []*model.Item{}

--- a/app/adapter/out/tidbrepository/find_delivery_units_projection_result_test.go
+++ b/app/adapter/out/tidbrepository/find_delivery_units_projection_result_test.go
@@ -440,7 +440,7 @@ var _ = Describe("FindDeliveryUnitsProjectionResult", func() {
 		Expect(results[0].LPN).To(Equal("LPN123"), "LPN incorrecto")
 		Expect(results[0].Volume).To(Equal(int64(6000)), "Volume incorrecto") // 10 * 20 * 30 = 6000 cm³
 		Expect(results[0].Weight).To(Equal(int64(5500)), "Weight incorrecto")
-		Expect(results[0].Insurance).To(Equal(int64(10000)), "Insurance incorrecto")
+		Expect(results[0].Insurance).To(Equal(int64(10000)), "Insurance incorrecto") // DB field still named insurance
 
 		// Validaciones de Items
 		Expect(results[0].JSONItems).To(HaveLen(1), "Debería tener un item")

--- a/app/adapter/out/tidbrepository/projectionresult/delivery_units_projection_result.go
+++ b/app/adapter/out/tidbrepository/projectionresult/delivery_units_projection_result.go
@@ -75,7 +75,7 @@ type DeliveryUnitsProjectionResult struct {
 	LPN                string              `json:"lpn"`
 	Volume             int64               `json:"volume"`
 	Weight             int64               `json:"weight"`
-	Insurance          int64               `json:"insurance"`
+	Insurance          int64               `json:"insurance"` // Kept as insurance for DB compatibility, maps to UnitPrice in domain
 	JSONItems          table.JSONItems     `json:"json_items"`
 	DeliveryUnitLabels table.JSONReference `json:"delivery_unit_labels" gorm:"column:delivery_unit_labels;type:jsonb"`
 

--- a/app/adapter/out/tidbrepository/table/delivery_unit.go
+++ b/app/adapter/out/tidbrepository/table/delivery_unit.go
@@ -19,7 +19,7 @@ type DeliveryUnit struct {
 	// Simplified fields (matching optimization domain)
 	Volume    int64     `gorm:"type:bigint;default:0;"`
 	Weight    int64     `gorm:"type:bigint;default:0;"`
-	Insurance int64     `gorm:"type:bigint;default:0;"`
+	UnitPrice int64     `gorm:"type:bigint;default:0;"`
 	JSONItems JSONItems `gorm:"type:json"`
 }
 
@@ -29,7 +29,7 @@ func (p DeliveryUnit) Map() domain.DeliveryUnit {
 		SizeCategory: p.SizeCategory.Map(),
 		Volume:       &p.Volume,
 		Weight:       &p.Weight,
-		Insurance:    &p.Insurance,
+		UnitPrice:    &p.UnitPrice,
 		Items:        p.JSONItems.Map(),
 	}
 }

--- a/app/adapter/out/tidbrepository/table/json_items.go
+++ b/app/adapter/out/tidbrepository/table/json_items.go
@@ -10,7 +10,7 @@ import (
 type Items struct {
 	Sku            string         `gorm:"not null" json:"sku"`
 	Quantity       int            `gorm:"not null" json:"quantity"`
-	Insurance      int64          `gorm:"not null" json:"insurance"`
+	Price          int64          `gorm:"not null" json:"price"`
 	Description    string         `gorm:"type:text" json:"description"`
 	JSONDimensions JSONDimensions `gorm:"type:json" json:"dimensions"`
 	Weight         int64          `gorm:"not null" json:"weight"`
@@ -20,7 +20,7 @@ func (i Items) Map() domain.Item {
 	return domain.Item{
 		Sku:         i.Sku,
 		Quantity:    i.Quantity,
-		Price:       i.Insurance,
+		Price:       i.Price,
 		Description: i.Description,
 		Dimensions:  i.JSONDimensions.Map(),
 		Weight:      i.Weight,

--- a/app/adapter/out/tidbrepository/table/mapper/map_order_tables.go
+++ b/app/adapter/out/tidbrepository/table/mapper/map_order_tables.go
@@ -111,15 +111,15 @@ func MapPackagesToTable(ctx context.Context, packages []domain.DeliveryUnit) []t
 		if pkg.Weight != nil {
 			wgt = *pkg.Weight
 		}
-		if pkg.Insurance != nil {
-			ins = *pkg.Insurance
+		if pkg.UnitPrice != nil {
+			ins = *pkg.UnitPrice
 		}
 		mapped[i] = table.DeliveryUnit{
 			TenantID:  sharedcontext.TenantIDFromContext(ctx),
 			Lpn:       pkg.Lpn,
 			Volume:    vol,
 			Weight:    wgt,
-			Insurance: ins,
+			UnitPrice: ins,
 			JSONItems: mapItemsToTable(pkg.Items),
 		}
 	}
@@ -134,8 +134,8 @@ func MapPackageToTable(ctx context.Context, pkg domain.DeliveryUnit) table.Deliv
 	if pkg.Weight != nil {
 		wgt = *pkg.Weight
 	}
-	if pkg.Insurance != nil {
-		ins = *pkg.Insurance
+	if pkg.UnitPrice != nil {
+		ins = *pkg.UnitPrice
 	}
 	return table.DeliveryUnit{
 		TenantID:        sharedcontext.TenantIDFromContext(ctx),
@@ -143,7 +143,7 @@ func MapPackageToTable(ctx context.Context, pkg domain.DeliveryUnit) table.Deliv
 		Lpn:             pkg.Lpn,
 		Volume:          vol,
 		Weight:          wgt,
-		Insurance:       ins,
+		UnitPrice:       ins,
 		JSONItems:       mapItemsToTable(pkg.Items),
 		SizeCategoryDoc: pkg.SizeCategory.DocumentID(ctx).String(),
 	}

--- a/app/adapter/out/tidbrepository/upsert_delivery_units.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units.go
@@ -75,8 +75,8 @@ func NewUpsertDeliveryUnits(conn database.ConnectionFactory, saveFSMTransition S
 					if updatedDomainPkg.Weight != nil {
 						updatedTablePkg.Weight = *updatedDomainPkg.Weight
 					}
-					if updatedDomainPkg.Insurance != nil {
-						updatedTablePkg.Insurance = *updatedDomainPkg.Insurance
+					if updatedDomainPkg.UnitPrice != nil {
+						updatedTablePkg.UnitPrice = *updatedDomainPkg.UnitPrice
 					}
 
 					DBpackagesToUpsert = append(DBpackagesToUpsert, updatedTablePkg)

--- a/app/adapter/out/tidbrepository/upsert_delivery_units_test.go
+++ b/app/adapter/out/tidbrepository/upsert_delivery_units_test.go
@@ -38,13 +38,13 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		// Crear paquetes para insertar
 		vol1 := int64(6000000)
 		wgt1 := int64(5000)
-		ins1 := int64(1000)
+		unitPrice1 := int64(1000)
 		package1 := domain.DeliveryUnit{
 			Lpn:          "PKG001",
 			SizeCategory: domain.SizeCategory{Code: "SMALL"},
 			Volume:       &vol1, // 1000 * 2000 * 3000 = 6000000 cm³
 			Weight:       &wgt1, // 5000 g
-			Insurance:    &ins1, // 1000 CLP
+			UnitPrice:    &unitPrice1, // 1000 CLP
 			Items: []domain.Item{
 				{
 					Sku:         "ITEM001",
@@ -57,13 +57,13 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 
 		vol2 := int64(13125000)
 		wgt2 := int64(7500)
-		ins2 := int64(0)
+		unitPrice2 := int64(0)
 		package2 := domain.DeliveryUnit{
 			Lpn:          "PKG002",
 			SizeCategory: domain.SizeCategory{Code: "MEDIUM"},
 			Volume:       &vol2, // 1500 * 2500 * 3500 = 13125000 cm³
 			Weight:       &wgt2, // 7500 g
-			Insurance:    &ins2, // Sin seguro
+			UnitPrice:    &unitPrice2, // Sin precio unitario
 		}
 
 		// Insertar los paquetes
@@ -94,7 +94,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		// Verificar los campos simplificados
 		Expect(dbPackage1.Volume).To(Equal(int64(6000000)))
 		Expect(dbPackage1.Weight).To(Equal(int64(5000)))
-		Expect(dbPackage1.Insurance).To(Equal(int64(1000)))
+		Expect(dbPackage1.UnitPrice).To(Equal(int64(1000)))
 
 		// Verificar items dentro del paquete
 		items := dbPackage1.JSONItems.Map()
@@ -307,7 +307,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 		// Verificar que los campos se actualizaron correctamente
 		Expect(updatedDBPackage.Volume).To(Equal(int64(13125)))
 		Expect(updatedDBPackage.Weight).To(Equal(int64(2000)))
-		Expect(updatedDBPackage.Insurance).To(Equal(int64(500)))
+		Expect(updatedDBPackage.UnitPrice).To(Equal(int64(500)))
 
 		// Verificar el nuevo paquete se insertó
 		var newDBPackage table.DeliveryUnit
@@ -475,7 +475,7 @@ var _ = Describe("UpsertDeliveryUnits", func() {
 
 		// Verificar que otros campos se mantuvieron igual
 		Expect(dbPackage.Volume).To(Equal(int64(6000)))
-		Expect(dbPackage.Insurance).To(Equal(int64(1000)))
+		Expect(dbPackage.UnitPrice).To(Equal(int64(1000)))
 
 		items := dbPackage.JSONItems.Map()
 		Expect(items[0].Description).To(Equal("Item original"))

--- a/app/adapter/out/vroom/mapper/map_optimization_request.go
+++ b/app/adapter/out/vroom/mapper/map_optimization_request.go
@@ -74,11 +74,11 @@ func getContactID(ctx context.Context, contact optimization.Contact) string {
 }
 
 // calculateVisitCapacity calcula la capacidad total de una visita basada en sus orders
-func calculateVisitCapacity(visit optimization.Visit) (totalWeight, totalDeliveryUnits, totalInsurance int64) {
+func calculateVisitCapacity(visit optimization.Visit) (totalWeight, totalDeliveryUnits, totalUnitPrice int64) {
 	for _, order := range visit.Orders {
 		for _, deliveryUnit := range order.DeliveryUnits {
 			totalWeight += deliveryUnit.Weight
-			totalInsurance += deliveryUnit.Insurance
+			totalUnitPrice += deliveryUnit.UnitPrice
 			totalDeliveryUnits++
 		}
 	}
@@ -136,7 +136,7 @@ func MapOptimizationRequest(ctx context.Context, req optimization.FleetOptimizat
 
 	for i, visit := range req.Visits {
 		// Calcular capacidad de la visita
-		totalWeight, totalDeliveryUnits, totalInsurance := calculateVisitCapacity(visit)
+		totalWeight, totalDeliveryUnits, totalUnitPrice := calculateVisitCapacity(visit)
 
 		// Verificar si hay pickup válido (coordenadas no son cero)
 		hasValidPickup := visit.Pickup.AddressInfo.Coordinates.Longitude != 0 || visit.Pickup.AddressInfo.Coordinates.Latitude != 0
@@ -172,7 +172,7 @@ func MapOptimizationRequest(ctx context.Context, req optimization.FleetOptimizat
 			job.Amount = []int64{
 				totalWeight,
 				totalDeliveryUnits,
-				totalInsurance,
+				totalUnitPrice,
 			}
 
 			// Recopilar skills de delivery units
@@ -259,7 +259,7 @@ func MapOptimizationRequest(ctx context.Context, req optimization.FleetOptimizat
 			shipment.Amount = []int64{
 				totalWeight,
 				totalDeliveryUnits,
-				totalInsurance,
+				totalUnitPrice,
 			}
 
 			// Recopilar skills de delivery units

--- a/app/domain/delivery_unit.go
+++ b/app/domain/delivery_unit.go
@@ -12,7 +12,7 @@ type DeliveryUnit struct {
 	noLPNReference  string
 	Volume          *int64
 	Weight          *int64
-	Insurance       *int64
+	UnitPrice       *int64
 	Status          Status
 	ConfirmDelivery ConfirmDelivery
 	Items           []Item
@@ -68,9 +68,9 @@ func (p DeliveryUnit) UpdateIfChanged(newPackage DeliveryUnit) (DeliveryUnit, bo
 		p.Weight = newPackage.Weight
 		changed = true
 	}
-	// Actualizar seguro si el puntero no es nil y el valor es diferente
-	if newPackage.Insurance != nil && (p.Insurance == nil || *newPackage.Insurance != *p.Insurance) {
-		p.Insurance = newPackage.Insurance
+	// Actualizar precio unitario si el puntero no es nil y el valor es diferente
+	if newPackage.UnitPrice != nil && (p.UnitPrice == nil || *newPackage.UnitPrice != *p.UnitPrice) {
+		p.UnitPrice = newPackage.UnitPrice
 		changed = true
 	}
 
@@ -96,10 +96,10 @@ func (p *DeliveryUnit) UpdateStatusBasedOnNonDelivery() {
 }
 
 // SetValues sets the simplified values directly
-func (p *DeliveryUnit) SetValues(volume, weight, insurance int64) {
+func (p *DeliveryUnit) SetValues(volume, weight, unitPrice int64) {
 	p.Volume = &volume
 	p.Weight = &weight
-	p.Insurance = &insurance
+	p.UnitPrice = &unitPrice
 }
 
 // ToOptimizationDeliveryUnit converts this DeliveryUnit to the optimization domain structure
@@ -117,9 +117,9 @@ func (p DeliveryUnit) ToOptimizationDeliveryUnit() optimization.DeliveryUnit {
 	}
 
 	// Use default values if pointers are nil
-	var insurance, volume, weight int64
-	if p.Insurance != nil {
-		insurance = *p.Insurance
+	var unitPrice, volume, weight int64
+	if p.UnitPrice != nil {
+		unitPrice = *p.UnitPrice
 	}
 	if p.Volume != nil {
 		volume = *p.Volume
@@ -130,7 +130,7 @@ func (p DeliveryUnit) ToOptimizationDeliveryUnit() optimization.DeliveryUnit {
 
 	return optimization.DeliveryUnit{
 		Items:     items,
-		Insurance: insurance,
+		UnitPrice: unitPrice,
 		Volume:    volume,
 		Weight:    weight,
 		Lpn:       p.Lpn,
@@ -156,7 +156,7 @@ func FromOptimizationDeliveryUnit(optDU optimization.DeliveryUnit) DeliveryUnit 
 		Lpn:       optDU.Lpn,
 		Volume:    &optDU.Volume,
 		Weight:    &optDU.Weight,
-		Insurance: &optDU.Insurance,
+		UnitPrice: &optDU.UnitPrice,
 		Items:     items,
 		Skills:    skills,
 	}

--- a/app/domain/delivery_unit_test.go
+++ b/app/domain/delivery_unit_test.go
@@ -155,12 +155,12 @@ var _ = Describe("Package", func() {
 		BeforeEach(func() {
 			vol := int64(6000)
 			wgt := int64(5000)
-			ins := int64(1000)
+			unitPrice := int64(1000)
 			basePackage = DeliveryUnit{
 				Lpn:       "PKG-TEST",
 				Volume:    &vol, // 10 * 20 * 30 = 6000 cm³
 				Weight:    &wgt, // 5 kg = 5000 g
-				Insurance: &ins, // 1000 CLP (simplified)
+				UnitPrice: &unitPrice, // 1000 CLP (simplified)
 				Items: []Item{
 					{
 						Sku:         "ITEM001",
@@ -190,7 +190,7 @@ var _ = Describe("Package", func() {
 			// Verificar que otros campos se mantienen igual
 			Expect(updated.Volume).To(Equal(basePackage.Volume))
 			Expect(updated.Weight).To(Equal(basePackage.Weight))
-			Expect(updated.Insurance).To(Equal(basePackage.Insurance))
+			Expect(updated.UnitPrice).To(Equal(basePackage.UnitPrice))
 			Expect(updated.Items).To(Equal(basePackage.Items))
 		})
 
@@ -207,7 +207,7 @@ var _ = Describe("Package", func() {
 			// Verificar que otros campos se mantienen igual
 			Expect(updated.Lpn).To(Equal(basePackage.Lpn))
 			Expect(updated.Weight).To(Equal(basePackage.Weight))
-			Expect(updated.Insurance).To(Equal(basePackage.Insurance))
+			Expect(updated.UnitPrice).To(Equal(basePackage.UnitPrice))
 			Expect(updated.Items).To(Equal(basePackage.Items))
 		})
 
@@ -224,20 +224,20 @@ var _ = Describe("Package", func() {
 			// Verificar que otros campos se mantienen igual
 			Expect(updated.Lpn).To(Equal(basePackage.Lpn))
 			Expect(updated.Volume).To(Equal(basePackage.Volume))
-			Expect(updated.Insurance).To(Equal(basePackage.Insurance))
+			Expect(updated.UnitPrice).To(Equal(basePackage.UnitPrice))
 			Expect(updated.Items).To(Equal(basePackage.Items))
 		})
 
-		It("should update Insurance", func() {
-			ins := int64(2000)
+		It("should update UnitPrice", func() {
+			unitPrice := int64(2000)
 			newPackage := DeliveryUnit{
-				Insurance: &ins, // 2000 CLP
+				UnitPrice: &unitPrice, // 2000 CLP
 			}
 
 			updated, changed := basePackage.UpdateIfChanged(newPackage)
 
 			Expect(changed).To(BeTrue())
-			Expect(updated.Insurance).To(Equal(newPackage.Insurance))
+			Expect(updated.UnitPrice).To(Equal(newPackage.UnitPrice))
 			// Verificar que otros campos se mantienen igual
 			Expect(updated.Lpn).To(Equal(basePackage.Lpn))
 			Expect(updated.Volume).To(Equal(basePackage.Volume))
@@ -271,7 +271,7 @@ var _ = Describe("Package", func() {
 			Expect(updated.Lpn).To(Equal(basePackage.Lpn))
 			Expect(updated.Volume).To(Equal(basePackage.Volume))
 			Expect(updated.Weight).To(Equal(basePackage.Weight))
-			Expect(updated.Insurance).To(Equal(basePackage.Insurance))
+			Expect(updated.UnitPrice).To(Equal(basePackage.UnitPrice))
 		})
 
 		It("should not update fields when new values are empty", func() {
@@ -310,7 +310,7 @@ var _ = Describe("Package", func() {
 			Expect(updated.Items).To(Equal(newPackage.Items))
 			// Estos campos no deberían cambiar
 			Expect(updated.Volume).To(Equal(basePackage.Volume))
-			Expect(updated.Insurance).To(Equal(basePackage.Insurance))
+			Expect(updated.UnitPrice).To(Equal(basePackage.UnitPrice))
 		})
 
 		It("should handle empty Items array", func() {
@@ -411,33 +411,33 @@ var _ = Describe("Package", func() {
 			Expect(*updated.Weight).To(Equal(int64(500)))
 		})
 
-		It("should update Insurance to zero", func() {
-			ins := int64(200)
+		It("should update UnitPrice to zero", func() {
+			unitPrice := int64(200)
 			zero := int64(0)
 			basePackage := DeliveryUnit{
-				Insurance: &ins,
+				UnitPrice: &unitPrice,
 			}
 			newPackage := DeliveryUnit{
-				Insurance: &zero,
+				UnitPrice: &zero,
 			}
 			updated, changed := basePackage.UpdateIfChanged(newPackage)
 			Expect(changed).To(BeTrue())
-			Expect(updated.Insurance).ToNot(BeNil())
-			Expect(*updated.Insurance).To(Equal(int64(0)))
+			Expect(updated.UnitPrice).ToNot(BeNil())
+			Expect(*updated.UnitPrice).To(Equal(int64(0)))
 		})
 
-		It("should not update Insurance if new value is nil", func() {
-			ins := int64(200)
+		It("should not update UnitPrice if new value is nil", func() {
+			unitPrice := int64(200)
 			basePackage := DeliveryUnit{
-				Insurance: &ins,
+				UnitPrice: &unitPrice,
 			}
 			newPackage := DeliveryUnit{
-				Insurance: nil,
+				UnitPrice: nil,
 			}
 			updated, changed := basePackage.UpdateIfChanged(newPackage)
 			Expect(changed).To(BeFalse())
-			Expect(updated.Insurance).ToNot(BeNil())
-			Expect(*updated.Insurance).To(Equal(int64(200)))
+			Expect(updated.UnitPrice).ToNot(BeNil())
+			Expect(*updated.UnitPrice).To(Equal(int64(200)))
 		})
 	})
 

--- a/app/domain/optimization/optimization.go
+++ b/app/domain/optimization/optimization.go
@@ -76,7 +76,7 @@ type Item struct {
 // DeliveryUnit representa una unidad de entrega
 type DeliveryUnit struct {
 	Items     []Item
-	Insurance int64
+	UnitPrice int64
 	Volume    int64
 	Weight    int64
 	Lpn       string

--- a/app/shared/projection/deliveryunits/projection.go
+++ b/app/shared/projection/deliveryunits/projection.go
@@ -351,8 +351,8 @@ func (p Projection) DeliveryUnitVolume() Field {
 	return Field{path: "deliveryUnit.volume"}
 }
 
-func (p Projection) DeliveryUnitInsurance() Field {
-	return Field{path: "deliveryUnit.insurance"}
+func (p Projection) DeliveryUnitUnitPrice() Field {
+	return Field{path: "deliveryUnit.unitPrice"}
 }
 
 // Métodos para campos de Label en Package


### PR DESCRIPTION
Rename `DeliveryUnit.Insurance` to `UnitPrice` to accurately reflect its meaning as the price of the deliverable unit.

---
<a href="https://cursor.com/background-agent?bcId=bc-4747db07-776c-41a3-a387-b48f4a43ae3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4747db07-776c-41a3-a387-b48f4a43ae3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

