### PR TITLE
Rename insurance to price attribute

### DIFF
--- a/app/adapter/in/fuegoapi/request/picking_visit_confirmed_request.go
+++ b/app/adapter/in/fuegoapi/request/picking_visit_confirmed_request.go
@@ -33,8 +33,8 @@ type PickingVisitConfirmedRequest struct {
 	} `json:"visit"`
 	Orders []struct {
 		DeliveryUnits []struct {
-			Insurance int `json:"insurance"`
-			Items     []struct {
+			Price int `json:"price"`
+			Items []struct {
 				Sku string `json:"sku"`
 			} `json:"items"`
 			Lpn    string `json:"lpn"`

--- a/app/adapter/in/fuegoapi/request/upsert_order_request.go
+++ b/app/adapter/in/fuegoapi/request/upsert_order_request.go
@@ -284,7 +284,7 @@ type UpsertOrderDeliveryUnit struct {
 	SizeCategory string             `json:"sizeCategory" example:"SMALL"`
 	Volume       *int64             `json:"volume" example:"1000" description:"Volume in cubic centimeters (cm³)"`
 	Weight       *int64             `json:"weight" example:"1000" description:"Weight in grams (g)"`
-	Insurance    *int64             `json:"insurance" example:"10000" description:"Insurance value in currency units (CLP, MXN, PEN, CENTS etc.) - only integer values accepted"`
+	Price        *int64             `json:"price" example:"10000" description:"Price value in currency units (CLP, MXN, PEN, etc.) - only integer values accepted"`
 	Skills       []string           `json:"skills"`
 	Labels       []UpsertOrderLabel `json:"labels"`
 	Items        []UpsertOrderItem  `json:"items"`
@@ -336,7 +336,7 @@ func (d UpsertOrderDeliveryUnit) Map() domain.DeliveryUnit {
 		SizeCategory: domain.SizeCategory{Code: d.SizeCategory},
 		Volume:       volumePtr,
 		Weight:       weightPtr,
-		Price:        d.Insurance,
+		Price:        d.Price,
 		Status:       domain.Status{Status: domain.StatusAvailable},
 		Skills:       skills,
 		Labels:       labels,


### PR DESCRIPTION
Rename `Insurance` to `Price` in `DeliveryUnit` and `Item` request DTOs to clarify cargo value.

This change aligns the `DeliveryUnit` and `Item` request structures with the `Price` concept for cargo value. The `Insurance` field is retained only for fleet optimization contexts, where it represents cargo insurance, and for vehicle insurance policies, which are distinct concepts.

---
<a href="https://cursor.com/background-agent?bcId=bc-4af1df5d-88e7-407d-974e-1fcb15a6ba33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4af1df5d-88e7-407d-974e-1fcb15a6ba33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

